### PR TITLE
49 get post and delete endpoints for events

### DIFF
--- a/src/pages/api/admins/eventRoutes.ts
+++ b/src/pages/api/admins/eventRoutes.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import connectDB from "../../../database/db"
+import Event from "../../../database/eventSchema"
+
+
+ 
+type ResponseData = {
+  message: string,
+  data: any
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+  
+) {
+    await connectDB();
+    if(req.method==="GET"){
+      try{
+        const allEvents=await Event.find({});
+        res.status(200).json({message:"Fetched all events.", data:allEvents})
+      } catch (err){
+        res.status(404).json({message:"GET Failed.", data:err})
+      }
+    }
+    else if(req.method==="POST"){
+        try{
+          const {title,description,date,location}=await req.body;
+          const event=await Event.create({title,description,date,location});
+          res.status(201).json({ message: 'Created event.' ,data:event})
+        } catch (err){
+          res.status(400).json({message:"POST Failed.", data:err})
+        }
+    }
+    else if(req.method==="DELETE"){
+        try{
+          const {id}=await req.body;
+          await Event.findByIdAndDelete({_id: id});
+          res.status(200).json({ message: 'Deleted event.', data:null})
+        } catch (err){
+          res.status(404).json({message:"DELETE Failed.", data:err})
+        }
+    }
+    else{
+      res.status(404).json({message:"Method Not Allowed", data:null})
+    }
+}

--- a/src/pages/api/users/eventRoutes.ts
+++ b/src/pages/api/users/eventRoutes.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import connectDB from "../../../database/db"
+import Event from "../../../database/eventSchema"
+
+
+ 
+type ResponseData = {
+  message: string,
+  data: any
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+  
+) {
+    await connectDB();
+    if(req.method==="GET"){
+      try{
+        const allEvents=await Event.find({});
+        res.status(200).json({message:"Fetched all events.", data:allEvents})
+      } catch (err){
+        res.status(404).json({message:"GET Failed.", data:err})
+      }
+    }
+  
+    else{
+      res.status(404).json({message:"Method Not Allowed", data:null})
+    }
+}

--- a/src/pages/api/users/eventRoutes.ts
+++ b/src/pages/api/users/eventRoutes.ts
@@ -32,6 +32,15 @@ export default async function handler(
           res.status(400).json({message:"POST Failed.", data:err})
         }
     }
+    else if(req.method==="DELETE"){
+        try{
+          const {id}=await req.body;
+          await Event.findByIdAndDelete({_id: id});
+          res.status(200).json({ message: 'Deleted event.', data:null})
+        } catch (err){
+          res.status(404).json({message:"DELETE Failed.", data:err})
+        }
+    }
     else{
       res.status(404).json({message:"Method Not Allowed", data:null})
     }

--- a/src/pages/api/users/eventRoutes.ts
+++ b/src/pages/api/users/eventRoutes.ts
@@ -23,7 +23,15 @@ export default async function handler(
         res.status(404).json({message:"GET Failed.", data:err})
       }
     }
-  
+    else if(req.method==="POST"){
+        try{
+          const {title,description,date,location}=await req.body;
+          const event=await Event.create({title,description,date,location});
+          res.status(201).json({ message: 'Created event.' ,data:event})
+        } catch (err){
+          res.status(400).json({message:"POST Failed.", data:err})
+        }
+    }
     else{
       res.status(404).json({message:"Method Not Allowed", data:null})
     }


### PR DESCRIPTION
## Developer: Sumedha Kundurt

Closes #49 

### Pull Request Summary

Created working GET, POST, and DELETE endpoints for events.

### Modifications

api/admins/eventRoutes.ts & api/users/eventRoutes.ts

### Testing Considerations

Tested creating an event, getting events, and deleting that event. Tested with forbidden methods and bad input.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}

<img width="864" alt="Screenshot 2024-03-31 at 19 39 41" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/70816655/3448cb11-d06b-41d6-a61a-bbe979a14456">
<img width="863" alt="Screenshot 2024-03-31 at 19 44 16" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/70816655/06e1f354-5333-4680-9d8f-dcffd4bc2cc8">
<img width="845" alt="Screenshot 2024-03-31 at 19 50 38" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/70816655/a6b283e0-47dd-4f07-96c4-b36044b504b5">
<img width="850" alt="Screenshot 2024-03-31 at 21 14 33" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/70816655/6b668019-e1b0-44cc-bcf3-68784e04f0d9">
<img width="870" alt="Screenshot 2024-03-31 at 21 13 43" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/70816655/c81a2409-b2b7-4c9e-aae6-9a1a942f3c8f">
