### PR TITLE
 90 create organization events page backend

### DIFF
--- a/src/admin_components/OrganizationEventsRequestTable.tsx
+++ b/src/admin_components/OrganizationEventsRequestTable.tsx
@@ -1,0 +1,485 @@
+import React, { useState, useEffect } from "react";
+import { DeleteOutline } from "@mui/icons-material";
+type AdminProps = {
+  events: {
+    organization: string;
+    title: string;
+    startDate: string;
+    endDate: string;
+    description?: string;
+    isVirtual: boolean;
+    location: string;
+    status: string;
+    deniedReason?: string;
+    imageLink?: string;
+    createdBy: string;
+    _id: string;
+  }[];
+  ITEMS_PER_PAGE: number;
+};
+
+interface PopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+  handleAction: (eventID: string, action: string) => void;
+  eventID: string;
+}
+
+const DeletePopup: React.FC<PopupProps> = ({
+  isOpen,
+  onClose,
+  handleAction,
+  eventID,
+}) => {
+  if (!isOpen) return null;
+  return (
+    <>
+      <div style={styles.transparentBackground} />
+      <div style={styles.popupContainer}>
+        <h2 style={{ textAlign: "center" }}>
+          Are you sure you want to delete this event?
+        </h2>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "center",
+          }}
+        >
+          <button
+            style={{
+              ...styles.buttons,
+              width: "122px",
+              height: "37.6px",
+              padding: "7.526px 10.752p",
+              fontSize: "17px",
+              margin: "0 4px 0 0",
+            }}
+            onMouseOver={(e: React.MouseEvent<HTMLButtonElement>) =>
+              ((e.target as HTMLButtonElement).style.backgroundColor =
+                "#e69153")
+            }
+            onMouseOut={(e: React.MouseEvent<HTMLButtonElement>) =>
+              ((e.target as HTMLButtonElement).style.backgroundColor =
+                "#f7ab74")
+            }
+            onClick={onClose}
+          >
+            No
+          </button>
+          <button
+            style={{
+              ...styles.buttons,
+              width: "324px",
+              height: "37.6px",
+              padding: "10px 39px",
+              fontSize: "17px",
+              margin: "0 0 0 4px",
+            }}
+            onMouseOver={(e: React.MouseEvent<HTMLButtonElement>) =>
+              ((e.target as HTMLButtonElement).style.backgroundColor =
+                "#e69153")
+            }
+            onMouseOut={(e: React.MouseEvent<HTMLButtonElement>) =>
+              ((e.target as HTMLButtonElement).style.backgroundColor =
+                "#f7ab74")
+            }
+            onClick={() => {
+              handleAction(eventID, "trash");
+              onClose();
+            }}
+          >
+            Yes, I want to delete this event
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default function AdminPage({ events, ITEMS_PER_PAGE }: AdminProps) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [currentEvents, setCurrentEvents] = useState(events);
+  // Delete popup
+  const [isDeletePopupOpen, setIsDeletePopupOpen] = useState(false);
+  const openDeletePopup = () => setIsDeletePopupOpen(true);
+  const closeDeletePopup = () => setIsDeletePopupOpen(false);
+
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const endIndex = Math.min(startIndex + ITEMS_PER_PAGE, events.length);
+
+  useEffect(() => {
+    // Update currentEvents whenever the events prop changes
+    setCurrentEvents(events);
+  }, [events]);
+
+  // Slice the events array to display only the items for the current page
+  const currentRequests = events.slice(startIndex, endIndex);
+
+  // Handle page change
+  const handlePageChange = (page: React.SetStateAction<number>) => {
+    setCurrentPage(page);
+  };
+
+  const calculateRange = () => {
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    const endIndex = Math.min(startIndex + ITEMS_PER_PAGE, events.length);
+    return { startIndex, endIndex };
+  };
+
+  const formatDate = (date: string) => {
+    var newDate = new Date(date);
+    return newDate.toLocaleDateString();
+  };
+
+  const getTime = (startDate: string, endDate: string) => {
+    var newStartDate = new Date(startDate);
+    var newEndDate = new Date(endDate);
+    return (
+      newStartDate.toLocaleTimeString([], {
+        timeStyle: "short",
+      }) +
+      " - " +
+      newEndDate.toLocaleTimeString([], {
+        timeStyle: "short",
+      })
+    );
+  };
+
+  const handleAction = async (eventID: string, action: string) => {
+    if (action === "trash") {
+      // Delete the event with the given _id
+      if (
+        eventID === events[events.length - 1]._id.toString() &&
+        currentPage !== 1
+      ) {
+        setCurrentPage(currentPage - 1);
+      }
+      await fetch("/api/users/eventRoutes/", {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ id: eventID }),
+      }).then((response) => response.json());
+      setCurrentEvents((currentEvents) =>
+        currentEvents.filter((event) => event._id !== eventID)
+      );
+    }
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "left",
+          boxSizing: "border-box",
+          width: "90rem",
+        }}
+      >
+        <table
+          style={{
+            border: "1px solid #f7f7f7",
+            borderCollapse: "collapse",
+            borderSpacing: 0,
+            borderBottom: "2px solid #f7f7f7",
+          }}
+        >
+          <thead>
+            <tr style={{ border: "1px solid #f7f7f7" }}>
+              <th
+                style={{
+                  padding: "10px",
+                  background: "#f7f7f7",
+                  border: "1px solid #f7f7f7",
+                }}
+              >
+                Event Name
+              </th>
+              <th
+                style={{
+                  padding: "10px",
+                  background: "#f7f7f7",
+                  fontWeight: 500,
+                  border: "1px solid #f7f7f7",
+                }}
+              >
+                Location
+              </th>
+              <th
+                style={{
+                  padding: "10px",
+                  background: "#f7f7f7",
+                  fontWeight: 500,
+                  border: "1px solid #f7f7f7",
+                }}
+              >
+                Status
+              </th>
+              <th
+                style={{
+                  padding: "10px",
+                  background: "#f7f7f7",
+                  fontWeight: 500,
+                  border: "1px solid #f7f7f7",
+                }}
+              >
+                Date & Time
+              </th>
+              <th
+                style={{
+                  padding: "10px",
+                  background: "#f7f7f7",
+                  fontWeight: 500,
+                  border: "1px solid #f7f7f7",
+                }}
+              >
+                Description
+              </th>
+              <th style={{ padding: "10px", background: "#f7f7f7" }}></th>{" "}
+              {/* Add this column for buttons */}
+            </tr>
+          </thead>
+          <tbody>
+            {currentEvents
+              .slice(calculateRange().startIndex, calculateRange().endIndex)
+              .map((event) => (
+                <>
+                  <tr key={event._id} style={{ border: "1px solid #f7f7f7" }}>
+                    <td style={{ ...styles.name, padding: "5px 50px" }}>
+                      {event.title}
+                    </td>
+                    <td style={{ ...styles.email, padding: "5px 50px" }}>
+                      {event.location}
+                    </td>
+                    <td
+                      style={{ ...styles.statusContainer, padding: "5px 50px" }}
+                    >
+                      <span
+                        style={{
+                          color:
+                            event.status === "Approved"
+                              ? "#007500"
+                              : event.status === "Denied"
+                              ? "#9C0006"
+                              : "#0d4f90",
+                          background:
+                            event.status === "Approved"
+                              ? "#DFF0D8"
+                              : event.status === "Denied"
+                              ? "#FADBD8"
+                              : "#d4eaff",
+
+                          padding: "5px 10px",
+                          borderRadius: "20px",
+                          fontWeight: "700px",
+                        }}
+                      >
+                        {event.status}
+                      </span>
+                    </td>
+                    <td style={{ padding: "5px 50px" }}>
+                      <span
+                        style={{
+                          ...styles.date,
+                          fontSize: "16px",
+                          color: "black",
+                          fontWeight: "700",
+                          display: "block",
+                        }}
+                      >
+                        {formatDate(event.startDate.toString())}
+                      </span>
+                      <span
+                        style={{
+                          ...styles.time,
+                          fontSize: "14px",
+                          color: "black",
+                          display: "block",
+                        }}
+                      >
+                        {getTime(
+                          event.startDate.toString(),
+                          event.endDate.toString()
+                        )}
+                      </span>
+                    </td>
+                    <td style={{ ...styles.description, padding: "5px 50px" }}>
+                      {event.description}
+                    </td>
+                    <td
+                      style={{
+                        ...styles.buttonContainer,
+                        padding: "20px 50px",
+                      }}
+                    >
+                      {event.status !== "Pending" ? ( // Render buttons based on status
+                        // Change Approve/Deny to trash can icon when status is "Accept"
+                        <>
+                          <button
+                            onClick={openDeletePopup}
+                            onMouseOver={(e) => {
+                              e.currentTarget.style.backgroundColor = "#FECACC";
+                            }}
+                            onMouseOut={(e) => {
+                              e.currentTarget.style.backgroundColor = "#F6E0E1";
+                            }}
+                            style={{
+                              padding: 0,
+                              background: "#f6e0e1",
+                              border: "none",
+                              cursor: "pointer",
+                              borderRadius: "100px",
+                              color: "#9C2C30",
+                            }}
+                          >
+                            <DeleteOutline
+                              style={{
+                                fontSize: 38,
+                                backgroundColor: "transparent",
+                                borderRadius: "100px",
+                                padding: "10px",
+                              }}
+                            />
+                          </button>
+                          <DeletePopup
+                            isOpen={isDeletePopupOpen}
+                            onClose={closeDeletePopup}
+                            handleAction={handleAction}
+                            eventID={event._id.toString()}
+                          />
+                        </>
+                      ) : (
+                        <></>
+                      )}
+                    </td>
+                  </tr>
+
+                  {event.deniedReason ? (
+                    <tr>
+                      <td
+                        style={{ color: "#9C2C30", fontStyle: "italic" }}
+                        align="left"
+                        colSpan={5}
+                      >
+                        Reason for declining: {event.deniedReason}
+                      </td>
+                    </tr>
+                  ) : (
+                    <></>
+                  )}
+                </>
+              ))}
+          </tbody>
+        </table>
+      </div>
+      <div
+        style={{ display: "flex", justifyContent: "center", marginTop: "20px" }}
+      >
+        {Array.from(
+          { length: Math.ceil(currentEvents.length / ITEMS_PER_PAGE) },
+          (_, index) => (
+            <button
+              key={index + 1}
+              style={{
+                margin: "5px",
+                padding: "5px 10px",
+                border: "0px",
+                borderRadius: "5px",
+                background: currentPage === index + 1 ? "#F0F8FF" : "white",
+                color: currentPage === index + 1 ? "#0080FF" : "black",
+                cursor: "pointer",
+              }}
+              onClick={() => handlePageChange(index + 1)}
+            >
+              {index + 1}
+            </button>
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+
+const styles: { [key: string]: React.CSSProperties } = {
+  mainContainer: {
+    display: "flex",
+    justifyContent: "space-evenly",
+  },
+  transparentBackground: {
+    top: "0",
+    left: "0",
+    width: "100%",
+    height: "100%",
+    position: "fixed",
+    opacity: "0.5",
+    background: "black",
+    zIndex: "999",
+  },
+  popupContainer: {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    position: "fixed",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    backgroundColor: "rgba(255,255,255,1)",
+    zIndex: "1000",
+    width: "649px",
+    height: "239px",
+  },
+  rightContainer: {
+    display: "flex",
+    flexDirection: "column",
+    background: "#D9D9D9",
+    alignItems: "center",
+    justifyContent: "flexStart",
+    overflow: "scroll",
+  },
+  name: {
+    textDecoration: "underline",
+  },
+  requestContainer: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    background: "white",
+    height: "15%",
+    width: "90%",
+    margin: "1%",
+  },
+  profileImage: {
+    margin: "5%",
+    borderRadius: "50%",
+  },
+  statusContainer: {},
+  buttons: {
+    width: "100%",
+    height: "100%",
+    border: "0px",
+    borderRadius: "9px",
+    background: "#f7ab74",
+    color: "black",
+    cursor: "pointer",
+    margin: "5%",
+  },
+  buttonContainer: {
+    display: "flex",
+    justifyContent: "space-evenly",
+    height: "50%",
+    width: "50%",
+  },
+  icon: {
+    backgroundColor: "transparent",
+  },
+  trashButton: {
+    background: "#F6E0E1",
+    color: "#9C2C30",
+    border: "0px",
+    cursor: "pointer",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+};

--- a/src/database/eventSchema.ts
+++ b/src/database/eventSchema.ts
@@ -1,24 +1,44 @@
 import mongoose, { Schema, Document } from "mongoose";
-
-// Interface for the Event document
-interface EventDocument extends Document {
+const EventSchema = new Schema(
+  {
+    organization: { type: String, required: true },
+    title: { type: String, required: true },
+    startDate: { type: Date, required: true },
+    endDate: { type: Date, required: true },
+    description: { type: String, required: false },
+    isVirtual: { type: Boolean, required: true },
+    location: {
+      type: String,
+      required: true,
+    },
+    status: { type: String, required: true, default: "Pending" },
+    deniedReason: { type: String, required: false },
+    imageLink: { type: String, required: false },
+    createdBy: { type: mongoose.Types.ObjectId, ref: "users", required: true },
+    _id: { type: mongoose.Types.ObjectId, required: true },
+  },
+  {
+    timestamps: true,
+  }
+);
+// For type inference that matches the schema.
+// THIS MUST MATCH THE SCHEMA
+export type EventDocument = {
+  organization: string;
   title: string;
-  description: string;
-  date: Date;
+  startDate: Date;
+  endDate: Date;
+  description?: string;
+  isVirtual: boolean;
   location: string;
-}
-
-// Schema for the Event
-const EventSchema: Schema<EventDocument> = new Schema({
-  title: { type: String, required: true },
-  description: { type: String, required: true },
-  date: { type: Date, required: true },
-  location: { type: String, required: true },
-});
-
+  status: string;
+  deniedReason?: string;
+  imageLink?: string;
+  createdBy: mongoose.Types.ObjectId;
+  _id: mongoose.Types.ObjectId;
+};
 // Export the Event model based on the schema
 const EventModel =
   mongoose.models.Events ||
   mongoose.model<EventDocument>("Events", EventSchema);
-
 export default EventModel;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,49 +2,58 @@ import { authMiddleware } from "@clerk/nextjs";
 import { NextRequest, NextResponse } from "next/server";
 
 interface UserMetadata {
-    role: string;
-    organization: string;
+  role: string;
+  organization: string;
 }
 
 export default authMiddleware({
-    async afterAuth(auth, req: NextRequest) {
-        // Define public routes
-        const publicRoutes = ["/", "/login", "/signup", "/forgot-password"];
+  async afterAuth(auth, req: NextRequest) {
+    // Define public routes
+    const publicRoutes = [
+      "/",
+      "/login",
+      "/signup",
+      "/forgot-password",
+      "/api/s3-upload/route",
+      "/api/test",
+      "/api/users/eventRoutes",
+      "/api/s3-upload/test",
+    ];
 
-        // Define route-specific permissions
-        const routePermissions: { [key: string]: string[] } = {
-            "/admin": ["admin"],
-            "/eventDetails": ["admin", "user"],
-            "/eventBar": ["admin", "user"],
-            "/calendar": ["admin", "user"],
-            "/confirmation-page": ["pending"],
-        };
+    // Define route-specific permissions
+    const routePermissions: { [key: string]: string[] } = {
+      "/admin": ["admin"],
+      "/eventDetails": ["admin", "user"],
+      "/eventBar": ["admin", "user"],
+      "/calendar": ["admin", "user"],
+      "/confirmation-page": ["pending"],
+    };
 
-        // Check if the current route is public
-        const isPublicRoute = publicRoutes.includes(req.nextUrl.pathname);
+    // Check if the current route is public
+    const isPublicRoute = publicRoutes.includes(req.nextUrl.pathname);
 
-        // Check if the user is authenticated
-        if (!auth.userId && !isPublicRoute) {
-            // Redirect unauthenticated users to sign-in page
-            const url = new URL("/login", req.url);
-            return NextResponse.redirect(url);
-        }
+    // Check if the user is authenticated
+    if (!auth.userId && !isPublicRoute) {
+      // Redirect unauthenticated users to sign-in page
+      const url = new URL("/login", req.url);
+      return NextResponse.redirect(url);
+    }
 
-        // Check if the user has access to the current route
-        const requiredRoles = routePermissions[req.nextUrl.pathname];
-        const metadata = auth?.sessionClaims?.unsafe_metadata as UserMetadata;
-        const role = metadata?.role;
-        if (requiredRoles && !requiredRoles.includes(role)) {
-            // Redirect users without the required role to a forbidden page or homepage
-            const url = new URL("/login", req.url);
-            return NextResponse.redirect(url);
-        }
+    // Check if the user has access to the current route
+    const requiredRoles = routePermissions[req.nextUrl.pathname];
+    const metadata = auth?.sessionClaims?.unsafe_metadata as UserMetadata;
+    const role = metadata?.role;
+    if (requiredRoles && !requiredRoles.includes(role)) {
+      // Redirect users without the required role to a forbidden page or homepage
+      const url = new URL("/login", req.url);
+      return NextResponse.redirect(url);
+    }
 
-        // Allow access to the requested route
-        return NextResponse.next();
-    },
+    // Allow access to the requested route
+    return NextResponse.next();
+  },
 });
 
 export const config = {
-    matcher: ["/((?!.+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
+  matcher: ["/((?!.+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],
 };

--- a/src/pages/api/users/eventRoutes.ts
+++ b/src/pages/api/users/eventRoutes.ts
@@ -1,47 +1,54 @@
-import type { NextApiRequest, NextApiResponse } from 'next'
-import connectDB from "../../../database/db"
-import Event from "../../../database/eventSchema"
+import type { NextApiRequest, NextApiResponse } from "next";
+import connectDB from "../../../database/db";
+import Event from "../../../database/eventSchema";
+import mongoose from "mongoose";
 
-
- 
 type ResponseData = {
-  message: string,
-  data: any
-}
+  message: string;
+  data: any;
+};
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ResponseData>
-  
+  res: NextApiResponse
 ) {
-    await connectDB();
-    if(req.method==="GET"){
-      try{
-        const allEvents=await Event.find({});
-        res.status(200).json({message:"Fetched all events.", data:allEvents})
-      } catch (err){
-        res.status(404).json({message:"GET Failed.", data:err})
+  await connectDB();
+  if (req.method === "GET") {
+    try {
+      const { _id } = req.query;
+      if (_id) {
+        const userId = new mongoose.Types.ObjectId(_id.toString());
+        const userEvents = await Event.find({ createdBy: userId });
+        if (!userEvents) {
+          res.status(404).json({ data: "User not found" });
+        }
+        res.status(200).json({ success: true, data: userEvents });
+      } else {
+        res
+          .status(404)
+          .json({ message: "GET Failed.", data: "No user supplied" });
       }
+    } catch (err) {
+      res.status(404).json({ message: "GET Failed.", data: err });
     }
-    else if(req.method==="POST"){
-        try{
-          const {title,description,date,location}=await req.body;
-          const event=await Event.create({title,description,date,location});
-          res.status(201).json({ message: 'Created event.' ,data:event})
-        } catch (err){
-          res.status(400).json({message:"POST Failed.", data:err})
-        }
+  } else if (req.method === "POST") {
+    try {
+      const { title, description, date, location } = await req.body;
+      const event = await Event.create({ title, description, date, location });
+      res.status(201).json({ message: "Created event.", data: event });
+    } catch (err) {
+      res.status(400).json({ message: "POST Failed.", data: err });
     }
-    else if(req.method==="DELETE"){
-        try{
-          const {id}=await req.body;
-          await Event.findByIdAndDelete({_id: id});
-          res.status(200).json({ message: 'Deleted event.', data:null})
-        } catch (err){
-          res.status(404).json({message:"DELETE Failed.", data:err})
-        }
+  } else if (req.method === "DELETE") {
+    try {
+      const { id } = req.body;
+
+      await Event.findByIdAndRemove(id.toString().trim());
+      res.status(200).json({ message: "Deleted event.", data: null });
+    } catch (err) {
+      res.status(404).json({ message: "DELETE Failed.", data: err });
     }
-    else{
-      res.status(404).json({message:"Method Not Allowed", data:null})
-    }
+  } else {
+    res.status(404).json({ message: "Method Not Allowed", data: null });
+  }
 }

--- a/src/pages/eventBar.tsx
+++ b/src/pages/eventBar.tsx
@@ -132,7 +132,10 @@ export default function EventBar({ events }: { events: EventDocument[] }) {
       <div style={styles.styles.mainContainer}>
         {/* add icon here */}
 
-        {events && events.map((event) => <Event key={event._id} {...event} />)}
+        {events &&
+          events.map((event) => (
+            <Event key={event._id.toString()} {...event} />
+          ))}
       </div>
     </div>
   );

--- a/src/pages/organizationEvents.tsx
+++ b/src/pages/organizationEvents.tsx
@@ -1,0 +1,139 @@
+import EventsTable from "../admin_components/OrganizationEventsRequestTable";
+import Layout from "../components/layout";
+import React, { useState, useEffect } from "react";
+import { useUser } from "@clerk/clerk-react";
+
+type eventType = {
+  organization: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  description?: string;
+  isVirtual: boolean;
+  location: string;
+  status: string;
+  deniedReason?: string;
+  imageLink?: string;
+  createdBy: string;
+  _id: string;
+};
+
+export default function OrganizationEvents() {
+  const [uid, setUID] = useState("");
+
+  const { user } = useUser();
+
+  const [approvedEvents, setApprovedEvents] = useState<eventType[]>([]);
+  const [deniedEvents, setDeniedEvents] = useState<eventType[]>([]);
+  const [pastEvents, setPastEvents] = useState<eventType[]>([]);
+  const [pendingEvents, setPendingEvents] = useState<eventType[]>([]);
+
+  // method to filter events seperate approved, denied, pending, and past
+  const filterStatusAndPastEndDate = (list: eventType[], status: string) => {
+    const currentDate = new Date();
+    return list.filter((event: eventType) => {
+      var eventDate = new Date(event.endDate);
+      return event.status === status && eventDate > currentDate;
+    });
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const uid_response = await fetch("/api/userRoutes/?clerkId=" + uid);
+        if (!uid_response.ok) {
+          throw new Error("Network response was not ok");
+        }
+        const user = await uid_response.json();
+
+        const _id_response = await fetch(
+          "/api/users/eventRoutes/?_id=" + user.data._id
+        );
+
+        if (!_id_response.ok) {
+          throw new Error("Network response was not ok");
+        }
+        const responseData = await _id_response.json();
+
+        const approved = filterStatusAndPastEndDate(
+          responseData.data,
+          "Approved"
+        );
+        //console.log(approved);
+        const denied = filterStatusAndPastEndDate(responseData.data, "Denied");
+        const pending = filterStatusAndPastEndDate(
+          responseData.data,
+          "Pending"
+        );
+
+        setApprovedEvents(approved);
+        setDeniedEvents(denied);
+        setPendingEvents(pending);
+        setPastEvents(
+          responseData.data.filter(
+            (event: eventType) =>
+              !approved.includes(event) &&
+              !denied.includes(event) &&
+              !pending.includes(event)
+          )
+        );
+      } catch (error) {}
+    };
+
+    if (user) {
+      setUID(user.id);
+      fetchData();
+    }
+  }, [user, uid]);
+  return (
+    <Layout>
+      {/* Requested Events */}
+      <div style={styles.container}>
+        <div>
+          <h1 style={{ alignSelf: "flex-start" }}>Outgoing Event Requests</h1>
+          <div style={{ height: "0.35714rem", background: "#F07F2D" }}></div>
+          <h3>Requested Events</h3>
+          <EventsTable ITEMS_PER_PAGE={4} events={pendingEvents} />
+        </div>
+        {/* Approved Events */}
+        <div>
+          <h2 style={{ alignSelf: "flex-start" }}>Active events</h2>
+          <div
+            style={{
+              height: "0.35714rem",
+              background: "#F07F2D",
+            }}
+          ></div>
+          <h3>Approved Events</h3>
+          <EventsTable ITEMS_PER_PAGE={1} events={approvedEvents} />
+        </div>
+
+        {/* Declined Events */}
+        <div>
+          <h3>Declined Events</h3>
+          <EventsTable ITEMS_PER_PAGE={1} events={deniedEvents} />
+        </div>
+        {/* Past Events */}
+        <div>
+          <h2 style={{ textAlign: "left" }}>Past events</h2>
+          <div
+            style={{
+              height: "0.35714rem",
+              background: "#335543",
+            }}
+          ></div>
+          <h3>Archived</h3>
+          <EventsTable ITEMS_PER_PAGE={3} events={pastEvents} />
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+const styles: { [key: string]: React.CSSProperties } = {
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+  },
+};

--- a/src/pages/organizationEvents.tsx
+++ b/src/pages/organizationEvents.tsx
@@ -47,7 +47,7 @@ export default function OrganizationEvents() {
         const user = await uid_response.json();
 
         const _id_response = await fetch(
-          "/api/users/eventRoutes/?_id=" + user.data._id
+          "/api/users/eventRoutes/?createdBy=" + user.data._id
         );
 
         if (!_id_response.ok) {


### PR DESCRIPTION
…nt requests etc. Connected to backend

## Developer: Matthew Bosio

Closes #90 

### Pull Request Summary

- created Organizations Events page where users (orgs) can see outgoing event requests, approved, denied, and past events. Accessible at /organizationEvents. Connected database events to page. 

### Modifications
- OrganizationsEventsRequestTable.tsx : component for organizationEvents page. Added delete event functionality.
- eventSchema.ts : changed event schema to work with changes required. Added a deniedReason (if event is denied), a createdBy (when an event is created this must be filled in to be the ObjectId of the currently signed in org/user), and changed status to a string (naming convention: Approved, Denied, Pending). 
- api/users/eventRoutes.ts : changed the GET route to get events by createdBy ID instead of just getting all users. Also modified the DELETE route slightly so it'd work properly.
- organizationEvents.tsx : created to represent the page where users can see their outgoing events. Fetches the events from the database. If an event date is already past, it is automatically put in the Archived Events.

### Testing Considerations

- if an event is added, it is not the organization page is not automatically rerendered (i.e. you can't see the new event without refreshing the page). I think this makes sense because users wont be on the page when they add an event.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

https://www.loom.com/share/5acf0a8a30814e2380faf99091aeb07c?sid=a0cf8d88-dbee-44fb-90da-99732983dc88
