### PR TITLE
feat: fix the show/hide button for different page sizes

### DIFF
--- a/src/pages/style/signup.module.css
+++ b/src/pages/style/signup.module.css
@@ -35,13 +35,6 @@
   width: 51%;
 }
 
-.inputContainer {
-  position: relative;
-  display: flex;
-  align-items: center;
-  width: 100%;
-}
-
 .label {
   font-family: "DM Sans", sans-serif;
   font-size: 1.5625em;
@@ -58,6 +51,13 @@
   border: 1px solid black;
   border-radius: 4px;
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+}
+
+.inputContainer {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
 }
 
 .bottomText {
@@ -133,7 +133,6 @@
     padding: 0.23em;
     padding-left: 0.5em;
     font-size: 1.3em;
-    width: 96%;
   }
 
   .bottomText {
@@ -144,6 +143,10 @@
     width: 20%;
     font-size: 1em;
     margin-top: 1em;
+  }
+
+  .inputContainer {
+    width: 100%;
   }
 }
 
@@ -185,6 +188,10 @@
   .button {
     width: 20%;
     font-size: 1.5em;
+  }
+
+  .inputContainer {
+    width: 100%;
   }
 }
 
@@ -229,6 +236,10 @@
     width: 25%;
     font-size: 2.5em;
   }
+
+  .inputContainer {
+    width: 100%;
+  }
 }
 
 /* Surface pro 7 */
@@ -272,6 +283,10 @@
     width: 25%;
     font-size: 2.5em;
   }
+
+  .inputContainer {
+    width: 100%;
+  }
 }
 
 /* Galaxy Fold */
@@ -313,6 +328,10 @@
     padding-top: 0.5em;
     padding-bottom: 0.5em;
     width: 25%;
+  }
+
+  .inputContainer {
+    width: 100%;
   }
 }
 
@@ -357,6 +376,10 @@
     margin-top: 1em;
     padding-top: 0.7em;
     padding-bottom: 0.7em;
+  }
+
+  .inputContainer {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Developer: Lindsay Minami

Closes #106 

### Pull Request Summary

Fix the button for show/hide on the signup page again

### Modifications

- Changes to styling on the signup.module.css (in the size dependent css)

### Testing Considerations

- Button for different sizing on different screens

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
Small Screen:
<img width="500" alt="Screenshot 2024-05-08 at 4 06 52 PM" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/20879552/c3fde1f1-c1d8-42d3-bb39-0df946b570f4">

Half Screen:
<img width="500" alt="Screenshot 2024-05-08 at 4 06 39 PM" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/20879552/64d7effa-1209-408c-8929-7884b470b762">

Full Screen:
<img width="500" alt="Screenshot 2024-05-08 at 4 06 27 PM" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/20879552/48844f9d-d2df-4207-9d03-a0255c3693b1">
