### PR TITLE
Fixed Public Calendar Page

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,7 +18,7 @@ export default authMiddleware({
         "/api/users/eventRoutes",
         "/api/s3-upload/test",
         "/publicCalendar",
-        "/eventDetails",
+        // "/eventDetails",
       ];
 
         // Define route-specific permissions


### PR DESCRIPTION
## Developer: Belal Elshenety

Closes #108 

### Pull Request Summary

Fixed Public Calendar page to populate from the backend. Removed eventDetails page from public routes so the website doesn't crash when navigating /eventDetails
### Modifications

publicCalendar.tsx: updated to populate events from backend
middleware.ts: removed eventDetails from public routes
### Testing Considerations

- Check all events are populating
- Click on events and check that it takes you to event details page
- navigate to /eventDetails and make sure that it doesn't crash
### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="1511" alt="Screenshot 2024-05-13 at 4 56 31 PM" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/113317327/1ef3a282-d03c-4d87-8c8e-929f111c8b9a">
