### PR TITLE
113 filter event bar

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,13 +18,13 @@ export default authMiddleware({
         "/api/users/eventRoutes",
         "/api/s3-upload/test",
         "/publicCalendar",
-        // "/eventDetails",
+        "/eventDetails",
       ];
 
         // Define route-specific permissions
         const routePermissions: { [key: string]: string[] } = {
             "/admin": ["admin"],
-            "/eventDetails": ["admin", "approved"],
+            // "/eventDetails": ["admin", "approved"],
             "/eventBar": ["admin", "approved"],
             "/calendar": ["admin", "approved"],
             "/confirmation-page": ["pending"],

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -94,18 +94,18 @@ export default function CalendarPage() {
       });
   }, []);
 
-  const handleDateClick = (arg) => {
-    const clickedDate = arg.dateStr;
-    const filteredEvents = events.filter((event) => {
-      const eventStart = new Date(event.startDate).toISOString().split("T")[0];
-      const eventEnd = new Date(event.endDate).toISOString().split("T")[0];
+  const handleDateClick = (arg: { dateStr: string }) => {
+    const clickedDate: string = arg.dateStr;
+    const filteredEvents: EventDocument[] = events.filter((event: EventDocument) => {
+      const eventStart: string = new Date(event.startDate).toISOString().split("T")[0];
+      const eventEnd: string = new Date(event.endDate).toISOString().split("T")[0];
       return clickedDate >= eventStart && clickedDate <= eventEnd;
     });
     setSelectedDateEvents(filteredEvents);
   };
 
-  const handleOutsideClick = (event) => {
-    if (calendarRef.current && !calendarRef.current.contains(event.target)) {
+  const handleOutsideClick = (event: MouseEvent) => {
+    if (calendarRef.current && !calendarRef.current.contains(event.target as Node)) {
       setSelectedDateEvents([]);
     }
   };

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -6,7 +6,7 @@ import timeGridPlugin from "@fullcalendar/timegrid";
 import EventBar from "./eventBar";
 import bootstrap5Plugin from "@fullcalendar/bootstrap5";
 import "bootstrap-icons/font/bootstrap-icons.css";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import React from "react";
 import AddEventPanel from "../components/addEventPanel";
 import Link from "next/link";
@@ -33,16 +33,15 @@ export interface Event {
 
 export default function CalendarPage() {
   const [events, setEvents] = useState<EventDocument[]>([]);
-  const [calenderEvents, setCalenderEvents] = useState<
-    FullCalenderRecurringEvent[]
-  >([]);
+  const [calendarEvents, setCalendarEvents] = useState<FullCalenderRecurringEvent[]>([]);
+  const [selectedDateEvents, setSelectedDateEvents] = useState<EventDocument[]>([]);
   const [resize, setResize] = useState(false);
   const [isAddingEvent, setIsAddingEvent] = useState(false);
   const [isShowingEventPopUp, setIsShowingEventPopUp] = useState(false);
-
   const [windowWidth, setWindowWidth] = useState(0);
   const { signOut } = useClerk();
   const router = useRouter();
+  const calendarRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setWindowWidth(window.innerWidth);
@@ -51,6 +50,7 @@ export default function CalendarPage() {
   const handleResize = () => {
     setWindowWidth(window.innerWidth);
   };
+
   const handleLogout = async () => {
     try {
       // Call signOut function to log out the current user
@@ -69,11 +69,9 @@ export default function CalendarPage() {
     };
   }, []);
 
-  // Anytime events change, re render the calendar events.
   useEffect(() => {
-    // setCalenderEvents .....
     if (!events) return;
-    setCalenderEvents(
+    setCalendarEvents(
       events.map((event) => ({
         startRecur: event.startDate,
         endRecur: event.endDate,
@@ -94,6 +92,29 @@ export default function CalendarPage() {
       .catch((error) => {
         console.error("Error fetching events:", error);
       });
+  }, []);
+
+  const handleDateClick = (arg) => {
+    const clickedDate = arg.dateStr;
+    const filteredEvents = events.filter((event) => {
+      const eventStart = new Date(event.startDate).toISOString().split("T")[0];
+      const eventEnd = new Date(event.endDate).toISOString().split("T")[0];
+      return clickedDate >= eventStart && clickedDate <= eventEnd;
+    });
+    setSelectedDateEvents(filteredEvents);
+  };
+
+  const handleOutsideClick = (event) => {
+    if (calendarRef.current && !calendarRef.current.contains(event.target)) {
+      setSelectedDateEvents([]);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("click", handleOutsideClick);
+    return () => {
+      document.removeEventListener("click", handleOutsideClick);
+    };
   }, []);
 
   const addEvent = (event: Event) => {};
@@ -164,59 +185,10 @@ export default function CalendarPage() {
         <EventRequestPopup onClose={() => setIsShowingEventPopUp(false)} />
       )}
       <Navbar />
-      <div className={style1.calendarPageContainer}>
+      <div className={style1.calendarPageContainer} ref={calendarRef}>
         <div className="calendar-container">
-          <div style={styles.signoutContainer}>
-            {/* <button
-              onClick={handleLogout}
-              onMouseOver={(e) =>
-                ((e.target as HTMLButtonElement).style.backgroundColor =
-                  "#e69153")
-              }
-              onMouseOut={(e) =>
-                ((e.target as HTMLButtonElement).style.backgroundColor =
-                  "#f7ab74")
-              }
-              className={style1.logoutButton}
-            >
-              Logout
-            </button>
-            <Link prefetch={false} href="/adminEvents">
-              <button
-            </button> */}
-            {/* <Link prefetch={false} href="/adminEvents">
-             <button
-                onMouseOver={(e) =>
-                  ((e.target as HTMLButtonElement).style.backgroundColor =
-                    "#e69153")
-                }
-                onMouseOut={(e) =>
-                  ((e.target as HTMLButtonElement).style.backgroundColor =
-                    "#f7ab74")
-                }
-                className={style1.adminButton}
-              >
-                Admin
-              </button>
-            </Link>
-            <Link prefetch={false} href="/profile">
-              <button
-                onMouseOver={(e) =>
-                  ((e.target as HTMLButtonElement).style.backgroundColor =
-                    "#e69153")
-                }
-                onMouseOut={(e) =>
-                  ((e.target as HTMLButtonElement).style.backgroundColor =
-                    "#f7ab74")
-                }
-                className={style1.adminButton}
-              >
-                Profile
-              </button>
-            </Link> */}
-          </div>
+          <div style={styles.signoutContainer}></div>
           <style>{calendarStyles}</style>
-
           <FullCalendar
             themeSystem="bootstrap5"
             plugins={[
@@ -251,9 +223,9 @@ export default function CalendarPage() {
             editable={true}
             select={() => {}}
             selectable={true}
-            events={calenderEvents}
+            events={calendarEvents}
+            dateClick={handleDateClick}
             eventClick={function (info) {
-              console.log(info.event);
               router.push({
                 pathname: "/eventDetails",
                 query: {
@@ -264,10 +236,9 @@ export default function CalendarPage() {
             eventColor="#c293ff"
           />
         </div>
-        {/* Conditionally render the Add Event button below the calendar for smaller screens */}
         {windowWidth < 786 && (
           <button
-            className={style1.addButton} // Ensure you have an 'addButton' style in your CSS module
+            className={style1.addButton}
             style={{ display: "block", margin: "20px auto 0" }}
             onClick={() => setIsAddingEvent((prev) => !prev)}
           >
@@ -275,7 +246,7 @@ export default function CalendarPage() {
           </button>
         )}
         {!isAddingEvent ? (
-          <EventBar events={events} />
+          <EventBar events={selectedDateEvents.length > 0 ? selectedDateEvents : events} />
         ) : (
           <AddEventPanel
             onClose={() => setIsAddingEvent(false)}
@@ -291,10 +262,6 @@ export default function CalendarPage() {
 const styles: { [key: string]: React.CSSProperties } = {
   spaced: {},
 };
-
-// calendarStyles is the same for all views
-
-// calendarStyles is the same for all views
 
 const calendarStyles = `
    .fc .fc-prev-button, .fc .fc-next-button {
@@ -312,32 +279,11 @@ const calendarStyles = `
    .fc .fc-AddEvent-button:hover {
      background-color: #eaeaea; 
    }
-   .fc .fc-prev-button, .fc .fc-next-button {
-     background-color: #335543;
-     border: none;
-     color: #FFF;
-     font-size: 2em;
-     font-size: 1.5em;
-     border-radius: 50%; 
-     line-height: 1;
-   }
-
-   .fc .fc-prev-button:hover,
-   .fc .fc-next-button:hover,
-   .fc .fc-AddEvent-button:hover {
-     background-color: #eaeaea; 
-   }
 
    .fc-prev-button {
      margin-left: 3%;
    }
-   .fc-prev-button {
-     margin-left: 3%;
-   }
 
-   .fc-next-button {
-     margin-right: 3%;
-   }
    .fc-next-button {
      margin-right: 3%;
    }
@@ -360,35 +306,11 @@ const calendarStyles = `
      align-items: center;
      justify-content: center;
    }
-   .fc-header-toolbar {
-     margin-top: 0%;
-     display: flex;
-     justify-content: space-between;
-     text-transform: uppercase;
-     padding-bottom: 1%;
-   }
-
-   .fc .fc-toolbar-title {
-     text-align: center;
-     margin-right: 2.5%;
-   }
-
-   .fc-toolbar-chunk {
-     display: flex;
-     align-items: center;
-     justify-content: center;
-   }
 
    .fc-toolbar-chunk:nth-child(2) {
      justify-content: center;
    }
-   .fc-toolbar-chunk:nth-child(2) {
-     justify-content: center;
-   }
 
-   .fc-toolbar-chunk:last-child {
-     justify-content: end;
-   }
    .fc-toolbar-chunk:last-child {
      justify-content: end;
    }
@@ -408,23 +330,7 @@ const calendarStyles = `
      width: 120px; /* Adjust the width as needed */
      height: 40px; /* Adjust the height as needed */
    }
-   .fc-col-header-cell {
-     background: #335543;
-     color: #FFF;
-   }
 
-   .fc .fc-AddEvent-button {
-     background-color: #F7AB74;
-     color: black;
-     border-radius: 0.9em;
-     border-color: #F7AB74;
-     font-size: 1.1em;
-     border: none;
-   }
-
-   .fc .fc-daygrid-event-harness {
-     max-width: 100%;
-   }
    .fc .fc-daygrid-event-harness {
      max-width: 100%;
    }
@@ -442,23 +348,7 @@ const calendarStyles = `
      align-items: center;
      box-sizing: border-box;
    }
-   .fc .fc-event {
-     background-color: #F7AB74;
-     border-color: #F7AB74;
-     color: black;
-     border-radius: 1em;
-     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-     padding: 5%;
-     padding-right: 25%;
-     display: flex;
-     justify-content: center;
-     align-items: center;
-     box-sizing: border-box;
-   }
 
-   .fc-daygrid-event-dot {
-     display: none;
-   }
    .fc-daygrid-event-dot {
      display: none;
    }
@@ -469,5 +359,4 @@ const calendarStyles = `
      border: 1px solid #ddd;
      border-right: 1px solid #ddd;
    }
-
  `;

--- a/src/pages/publicCalendar.tsx
+++ b/src/pages/publicCalendar.tsx
@@ -98,18 +98,18 @@ export default function CalendarPage() {
       });
   }, []);
 
-  const handleDateClick = (arg) => {
-    const clickedDate = arg.dateStr;
-    const filteredEvents = events.filter((event) => {
-      const eventStart = new Date(event.startDate).toISOString().split("T")[0];
-      const eventEnd = new Date(event.endDate).toISOString().split("T")[0];
+  const handleDateClick = (arg: { dateStr: string }) => {
+    const clickedDate: string = arg.dateStr;
+    const filteredEvents: EventDocument[] = events.filter((event: EventDocument) => {
+      const eventStart: string = new Date(event.startDate).toISOString().split("T")[0];
+      const eventEnd: string = new Date(event.endDate).toISOString().split("T")[0];
       return clickedDate >= eventStart && clickedDate <= eventEnd;
     });
     setSelectedDateEvents(filteredEvents);
   };
 
-  const handleOutsideClick = (event) => {
-    if (calendarRef.current && !calendarRef.current.contains(event.target)) {
+  const handleOutsideClick = (event: MouseEvent) => {
+    if (calendarRef.current && !calendarRef.current.contains(event.target as Node)) {
       setSelectedDateEvents([]);
     }
   };


### PR DESCRIPTION
## Developer: Belal Elshenety

Closes #113 

### Pull Request Summary

When selecting a specific day in the public or private calendar, only events on that day are populating in the event bar. When the selected day doesn't have any events or when you click outside the calendar (to deselect day), all events populate to the event bar.
### Modifications

calendar.tsx: mada a SelectedDateEvents variable that populates to the event bar only when a date is selected and it has events
publicCalendar.tsx: same as calendar.tsx
middleware.ts: add eventDetails to public routes so when you click an event, it doesn't go to login but rather takes you to eventDetails page.
### Testing Considerations

- Check all events are populating on the same days listed in the backend
- Check that you can see eventDetails without logging in
### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="1512" alt="Screenshot 2024-05-14 at 12 13 33 AM" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/113317327/f1b7f744-acb7-4a4a-bed2-9ae74844064b">
<img width="1460" alt="Screenshot 2024-05-14 at 12 13 42 AM" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/113317327/dedd369f-ab05-4fc2-97f1-8237a0f38f4a">
