### PR TITLE
Feat: finally done

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "formidable": "^3.5.1",
         "fs": "^0.0.1-security",
         "leaflet": "^1.9.4",
+        "luxon": "^3.4.4",
         "mongoose": "^7.6.3",
         "multer": "^1.4.5-lts.1",
         "next": "14.0.0",
@@ -48,6 +49,7 @@
       "devDependencies": {
         "@types/express": "^4.17.21",
         "@types/formidable": "^3.4.5",
+        "@types/luxon": "^3.4.2",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -3339,6 +3341,12 @@
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
       "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="
     },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
+      "dev": true
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -6625,6 +6633,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/map-obj": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "formidable": "^3.5.1",
     "fs": "^0.0.1-security",
     "leaflet": "^1.9.4",
+    "luxon": "^3.4.4",
     "mongoose": "^7.6.3",
     "multer": "^1.4.5-lts.1",
     "next": "14.0.0",
@@ -50,6 +51,7 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/formidable": "^3.4.5",
+    "@types/luxon": "^3.4.2",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -17,6 +17,7 @@ import { EventDocument } from "database/eventSchema";
 import { useRouter } from "next/router";
 import { convertEventDatesToDates } from "../utils/events";
 import Navbar from "../components/navbar";
+import { DateTime } from "luxon";
 
 // Recurring because events may span multiple days.
 // This still works for single-day events.
@@ -95,14 +96,26 @@ export default function CalendarPage() {
   }, []);
 
   const handleDateClick = (arg: { dateStr: string }) => {
-    const clickedDate: string = arg.dateStr;
+    const clickedDate = new Date(arg.dateStr);
+  
     const filteredEvents: EventDocument[] = events.filter((event: EventDocument) => {
-      const eventStart: string = new Date(event.startDate).toISOString().split("T")[0];
-      const eventEnd: string = new Date(event.endDate).toISOString().split("T")[0];
-      return clickedDate >= eventStart && clickedDate <= eventEnd;
+      const eventStart = DateTime.fromISO(event.startDate.toISOString(), { zone: 'UTC' })
+        .setZone('America/Los_Angeles')
+        .toISODate();
+      const eventEnd = DateTime.fromISO(event.endDate.toISOString(), { zone: 'UTC' })
+        .setZone('America/Los_Angeles')
+        .toISODate();
+  
+      if (!eventStart || !eventEnd) {
+        return false;
+      }
+  
+      return clickedDate >= new Date(eventStart) && clickedDate <= new Date(eventEnd);
     });
+  
     setSelectedDateEvents(filteredEvents);
   };
+  
 
   const handleOutsideClick = (event: MouseEvent) => {
     if (calendarRef.current && !calendarRef.current.contains(event.target as Node)) {

--- a/src/pages/publicCalendar.tsx
+++ b/src/pages/publicCalendar.tsx
@@ -17,6 +17,8 @@ import { EventDocument } from "database/eventSchema";
 import { useRouter } from "next/router";
 import { convertEventDatesToDates } from "../utils/events";
 import Navbar from "../components/navbar";
+import { DateTime } from 'luxon';
+
 
 // Recurring because events may span multiple days.
 // This still works for single-day events.
@@ -99,14 +101,26 @@ export default function CalendarPage() {
   }, []);
 
   const handleDateClick = (arg: { dateStr: string }) => {
-    const clickedDate: string = arg.dateStr;
+    const clickedDate = new Date(arg.dateStr);
+  
     const filteredEvents: EventDocument[] = events.filter((event: EventDocument) => {
-      const eventStart: string = new Date(event.startDate).toISOString().split("T")[0];
-      const eventEnd: string = new Date(event.endDate).toISOString().split("T")[0];
-      return clickedDate >= eventStart && clickedDate <= eventEnd;
+      const eventStart = DateTime.fromISO(event.startDate.toISOString(), { zone: 'UTC' })
+        .setZone('America/Los_Angeles')
+        .toISODate();
+      const eventEnd = DateTime.fromISO(event.endDate.toISOString(), { zone: 'UTC' })
+        .setZone('America/Los_Angeles')
+        .toISODate();
+  
+      if (!eventStart || !eventEnd) {
+        return false;
+      }
+  
+      return clickedDate >= new Date(eventStart) && clickedDate <= new Date(eventEnd);
     });
+  
     setSelectedDateEvents(filteredEvents);
   };
+  
 
   const handleOutsideClick = (event: MouseEvent) => {
     if (calendarRef.current && !calendarRef.current.contains(event.target as Node)) {


### PR DESCRIPTION
That was so annoying

## Developer: Belal Elshenety

Closes #117 

### Pull Request Summary

Basically changed my filter so it uses the Los Angeles time instead of the time of the backend. The backend has a different time zone, which took me forever to figure out. The dates and times displayed on the website are the actual dates the user entered. The dates in the DB are same dates and times but in a different time zone, which means we always have to convert to LA time before we use the date for anything
### Modifications

calendar.tsx, publicCalendar.tsx: filters using LA time. Conversion is done using luxon.
### Testing Considerations

Make a new event and check that the date and time you entered are the same as the ones on eventDetails page, calendar, and the filter. Will be different from DB as it is set to a different time zone
### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast


https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/113317327/f994ed9d-55c4-4eae-969d-1e2b4229be97
