### PR TITLE
125 preview event details from management pages

### DIFF
--- a/src/admin_components/EventsRequestTable.tsx
+++ b/src/admin_components/EventsRequestTable.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { DeleteOutline } from "@mui/icons-material";
+import { useRouter } from "next/router";
 
 type AdminProps = {
   events: {
@@ -255,6 +256,7 @@ export default function AdminPage({
 }: AdminProps) {
   const [currentPage, setCurrentPage] = useState(1);
   const profileImage = require("../images/profileImage.webp");
+  const router = useRouter();
   
 
   // Delete popup
@@ -418,7 +420,17 @@ export default function AdminPage({
               .slice(calculateRange().startIndex, calculateRange().endIndex)
               .map((request) => (
                 <tr key={request._id} style={{ border: "1px solid #f7f7f7" }}>
-                  <td style={{ ...styles.name, padding: "5px 50px" }}>
+                  <td 
+                  style={{ ...styles.name, padding: "5px 50px" }}
+                  onClick={function (info) {
+                    router.push({
+                      pathname: "/eventDetails",
+                      query: {
+                        eventId: request._id,
+                      },
+                    });
+                  }}
+                  >
                     {request.title}
                   </td>
                   <td style={{ ...styles.email, padding: "5px 50px" }}>

--- a/src/admin_components/OrganizationEventsRequestTable.tsx
+++ b/src/admin_components/OrganizationEventsRequestTable.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { DeleteOutline } from "@mui/icons-material";
+import { useRouter } from "next/router";
+
 type AdminProps = {
   events: {
     organization: string;
@@ -98,6 +100,7 @@ const DeletePopup: React.FC<PopupProps> = ({
 };
 
 export default function AdminPage({ events, ITEMS_PER_PAGE }: AdminProps) {
+  const router = useRouter();
   const [currentPage, setCurrentPage] = useState(1);
   const [currentEvents, setCurrentEvents] = useState(events);
   // Delete popup
@@ -247,7 +250,17 @@ export default function AdminPage({ events, ITEMS_PER_PAGE }: AdminProps) {
               .map((event) => (
                 <>
                   <tr key={event._id} style={{ border: "1px solid #f7f7f7" }}>
-                    <td style={{ ...styles.name, padding: "5px 50px" }}>
+                    <td 
+                    style={{ ...styles.name, padding: "5px 50px" }}
+                    onClick={function (info) {
+                      router.push({
+                        pathname: "/eventDetails",
+                        query: {
+                          eventId: event._id,
+                        },
+                      });
+                    }}
+                    >
                       {event.title}
                     </td>
                     <td style={{ ...styles.email, padding: "5px 50px" }}>

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -9,7 +9,6 @@ import "bootstrap-icons/font/bootstrap-icons.css";
 import { useEffect, useState, useRef } from "react";
 import React from "react";
 import AddEventPanel from "../components/addEventPanel";
-import Link from "next/link";
 import EventRequestPopup from "../components/eventRequestPopup";
 import style1 from "../styles/calendar.module.css";
 import { useClerk } from "@clerk/clerk-react";
@@ -52,16 +51,7 @@ export default function CalendarPage() {
     setWindowWidth(window.innerWidth);
   };
 
-  const handleLogout = async () => {
-    try {
-      // Call signOut function to log out the current user
-      await signOut();
-      // Redirect to a different page after logout if needed
-      window.location.href = "/login";
-    } catch (error) {
-      console.error("Error logging out:", error);
-    }
-  };
+
 
   useEffect(() => {
     window.addEventListener("resize", handleResize);

--- a/src/pages/eventDetails.tsx
+++ b/src/pages/eventDetails.tsx
@@ -4,6 +4,7 @@ import StaticMap from "../components/map";
 import { EventDocument } from "../database/eventSchema";
 import { useRouter } from "next/router";
 import { convertEventDatesToDates, getFormattedDate } from "../utils/events";
+import { red } from "@mui/material/colors";
 
 interface Address {
   street: string;
@@ -31,11 +32,6 @@ export default function EventPage() {
   const eventId = router.query.eventId;
 
   useEffect(() => {
-    if (!eventId) {
-      router.push("/calendar");
-      return;
-    }
-
     const fetchEvent = async () => {
       try {
         const response = await fetch(`/api/users/eventRoutes?id=${eventId}`);
@@ -66,6 +62,13 @@ export default function EventPage() {
       {event && (
         <div style={styles.container}>
           <div style={styles.box}>
+            {event.status === "Pending" && (
+              <h1 style={{ color: "green" }}>PREVIEW OF EVENT</h1>
+            )}
+            {event.status === "Denied" && (
+              <h1 style={{ color: "red" }}>DENIED</h1>
+            )}
+
             <h1 style={styles.title}>{event.title}</h1>
             <p style={styles.date}>
               {`Starts on ${getFormattedDate(event.startDate)}`}
@@ -137,6 +140,18 @@ const styles: { [key: string]: React.CSSProperties } = {
     width: "100%",
     maxWidth: "600px",
     textAlign: "left",
+  },
+  centeredBox: {
+    backgroundColor: "white",
+    padding: "50px",
+    borderRadius: "8px",
+    width: "100%",
+    maxWidth: "600px",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    textAlign: "center",
+    height: "100vh", // Make the box take the full height of the viewport
   },
   title: {
     fontFamily: "DM Sans",

--- a/src/pages/organizationEvents.tsx
+++ b/src/pages/organizationEvents.tsx
@@ -3,6 +3,7 @@ import Layout from "../components/layout";
 import React, { useState, useEffect } from "react";
 import { useUser } from "@clerk/clerk-react";
 
+
 type eventType = {
   organization: string;
   title: string;


### PR DESCRIPTION
## Developer: Belal Elshenety

Closes #125 

### Pull Request Summary

This pull request allows organizations and admins to view event details based on their status. Pending events will show a preview page with "PREVIEW OF EVENT" at the top, while denied events will show "DENIED" at the top of the regular event details page. Approved and archived events will redirect directly to the regular event details page when the title is clicked.

### Modifications

EventsRequestTable & OrganizationEventsRequestTable: on clicking event name, it routes to events details
eventDetails: shows Red DENIED header if event is denied and Green PREVIEW OF EVENT if event is pending 
### Testing Considerations
Open different type of events:
- Denied event should have DENIED header in eventdetails page
- Pending event should have PREVIEW OF EVENT 
- Other event shouldn't have anything extra

Click on event name in My events page of both admin and organization to route to event details page
### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="738" alt="Screenshot 2024-05-17 at 11 30 12 PM" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/113317327/e13f29bc-e800-4451-b7f8-a7d785d6f038">
<img width="730" alt="Screenshot 2024-05-17 at 11 30 03 PM" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/113317327/9d1f9d9a-6c33-4cbf-bd42-da6f21bb192e">

https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/113317327/8762958c-1d82-4dff-84cd-bbe2607d37a8

