### PR TITLE
fix: the event bar only has current/future events but users can still…

### DIFF
--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -32,6 +32,7 @@ export interface Event {
 
 export default function CalendarPage() {
   const [events, setEvents] = useState<EventDocument[]>([]);
+  const [futureEvents, setFutureEvents] = useState<EventDocument[]>([]);
   const [calendarEvents, setCalendarEvents] = useState<FullCalenderRecurringEvent[]>([]);
   const [selectedDateEvents, setSelectedDateEvents] = useState<EventDocument[]>([]);
   const [resize, setResize] = useState(false);
@@ -50,7 +51,9 @@ export default function CalendarPage() {
     setWindowWidth(window.innerWidth);
   };
 
-
+  useEffect(() => {
+    setFutureEvents(filterFutureEvents(events))
+  }, [events])
 
   useEffect(() => {
     window.addEventListener("resize", handleResize);
@@ -86,6 +89,7 @@ useEffect(() => {
 
   const handleDateClick = (arg: { dateStr: string }) => {
     const clickedDate = new Date(arg.dateStr);
+    console.log(clickedDate)
   
     const filteredEvents: EventDocument[] = events.filter((event: EventDocument) => {
       const eventStart = DateTime.fromISO(event.startDate.toISOString(), { zone: 'UTC' })
@@ -96,19 +100,32 @@ useEffect(() => {
         .toISODate();
   
       if (!eventStart || !eventEnd) {
+        console.log("False")
         return false;
       }
   
       return clickedDate >= new Date(eventStart) && clickedDate <= new Date(eventEnd);
     });
+    console.log(filteredEvents)
   
     setSelectedDateEvents(filteredEvents);
   };
   
 
+  const filterFutureEvents = (events: EventDocument[]) => {
+    const now = new Date();
+    return events
+      .filter(event => {
+        const eventStart = new Date(event.startDate);
+        const eventEnd = new Date(event.endDate);
+        return (eventStart <= now && eventEnd >= now) || eventStart >= now;
+      })
+      .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime());
+  };
+
   const handleOutsideClick = (event: MouseEvent) => {
     if (calendarRef.current && !calendarRef.current.contains(event.target as Node)) {
-      setSelectedDateEvents([]);
+      setSelectedDateEvents(filterFutureEvents(events));
     }
   };
 
@@ -117,7 +134,7 @@ useEffect(() => {
     return () => {
       document.removeEventListener("click", handleOutsideClick);
     };
-  }, []);
+  }, [events]);
 
   const addEvent = (event: Event) => {};
 
@@ -248,7 +265,7 @@ useEffect(() => {
           </button>
         )}
         {!isAddingEvent ? (
-          <EventBar events={selectedDateEvents.length > 0 ? selectedDateEvents : events} />
+          <EventBar events={selectedDateEvents.length > 0 ? selectedDateEvents : futureEvents} />
         ) : (
           <AddEventPanel
             onClose={() => setIsAddingEvent(false)}

--- a/src/pages/eventBar.tsx
+++ b/src/pages/eventBar.tsx
@@ -94,7 +94,8 @@ export default function EventBar({ events }: { events: EventDocument[] }) {
   const [filteredEvents, setFilteredEvents] = useState<EventDocument[]>(
     events || []
   );
-  
+
+
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
     setSearchTerm(value);
@@ -104,18 +105,22 @@ export default function EventBar({ events }: { events: EventDocument[] }) {
       );
       setFilteredEvents(filtered);
     } else {
-      setFilteredEvents(filterFutureEvents(events));
+      setFilteredEvents(events);
     }
   };
 
   useEffect(() => {
-    setFilteredEvents(filterFutureEvents(events || []));
+    setFilteredEvents(events || []);
   }, [events]);
 
-  const filterFutureEvents = (events: EventDocument[]) => {
-    const now = new Date();
-    return events.filter(event => new Date(event.startDate) >= now);
-  };
+  // const filterFutureEvents = (events: EventDocument[]) => {
+  //   const now = new Date();
+  //   console.log(now)
+  //   return events.filter(event => (new Date(event.startDate) >= now )&& (new Date(event.startDate).getTime >= now.getTime)).sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
+  // };
+  
+
+      
 
   return (
     <div

--- a/src/pages/eventBar.tsx
+++ b/src/pages/eventBar.tsx
@@ -94,20 +94,28 @@ export default function EventBar({ events }: { events: EventDocument[] }) {
   const [filteredEvents, setFilteredEvents] = useState<EventDocument[]>(
     events || []
   );
-
+  
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
     setSearchTerm(value);
-    const filtered = (events || []).filter((event) =>
-      event.title.toLowerCase().includes(value.toLowerCase())
-    );
-
-    setFilteredEvents(filtered);
+    if (value) {
+      const filtered = (events || []).filter((event) =>
+        event.title.toLowerCase().includes(value.toLowerCase())
+      );
+      setFilteredEvents(filtered);
+    } else {
+      setFilteredEvents(filterFutureEvents(events));
+    }
   };
 
   useEffect(() => {
-    setFilteredEvents(events || []);
+    setFilteredEvents(filterFutureEvents(events || []));
   }, [events]);
+
+  const filterFutureEvents = (events: EventDocument[]) => {
+    const now = new Date();
+    return events.filter(event => new Date(event.startDate) >= now);
+  };
 
   return (
     <div

--- a/src/pages/publicCalendar.tsx
+++ b/src/pages/publicCalendar.tsx
@@ -37,6 +37,7 @@ export default function CalendarPage() {
   const [calendarEvents, setCalendarEvents] = useState<
     FullCalenderRecurringEvent[]
   >([]);
+  const [futureEvents, setFutureEvents] = useState<EventDocument[]>([]);
   const [selectedDateEvents, setSelectedDateEvents] = useState<EventDocument[]>(
     []
   );
@@ -57,6 +58,21 @@ export default function CalendarPage() {
      router.push("/calendar");
   }
   }, [clerk.user]);
+
+  useEffect(() => {
+    setFutureEvents(filterFutureEvents(events))
+  }, [events])
+
+  const filterFutureEvents = (events: EventDocument[]) => {
+    const now = new Date();
+    return events
+      .filter(event => {
+        const eventStart = new Date(event.startDate);
+        const eventEnd = new Date(event.endDate);
+        return (eventStart <= now && eventEnd >= now) || eventStart >= now;
+      })
+      .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime());
+  };
 
   useEffect(() => {
     setWindowWidth(window.innerWidth);
@@ -265,7 +281,7 @@ export default function CalendarPage() {
         )}
         {!isAddingEvent ? (
           <EventBar
-            events={selectedDateEvents.length > 0 ? selectedDateEvents : events}
+            events={selectedDateEvents.length > 0 ? selectedDateEvents : futureEvents}
           />
         ) : (
           <AddEventPanel


### PR DESCRIPTION
… search past events

## Developer: Jodi Yamane

Closes #133 

### Pull Request Summary

I was supposed to fix the event bar so that it only showed upcoming events and not events that already happened. Users can still search up past events.

### Modifications

eventBar.tsx was changed. I added a filterFutureEvents function, which filters out the events so that there are only future events. I applied that function to the useEffect and the handleSearchChange. I also changed handleSearchChange so that the user can search up past events and not just the future events.

### Testing Considerations

I'm not sure if the event that's on the day of will pop up in the event bar (e.g. if an event on 5/23 will pop up if the user is looking on 5/23). I didn't know if it will take into account the time that the event will be or only the day.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}

(taken on 5/22)
![image](https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/93350457/7405afbe-e643-45aa-97bf-08d568668742)
![image](https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/93350457/fa82365c-bd44-426e-8757-9d771eef4195)
