### PR TITLE
120 handle blank event and user sections

### DIFF
--- a/src/admin_components/EventsRequestTable.tsx
+++ b/src/admin_components/EventsRequestTable.tsx
@@ -349,7 +349,7 @@ export default function AdminPage({
           display: "flex",
           justifyContent: "left",
           boxSizing: "border-box",
-          width: "90rem",
+          width: "100%",
         }}
       >
         <table
@@ -358,6 +358,7 @@ export default function AdminPage({
             borderCollapse: "collapse",
             borderSpacing: 0,
             borderBottom: "2px solid #f7f7f7",
+            width: "100%"
           }}
         >
           <thead>

--- a/src/admin_components/OrganizationEventsRequestTable.tsx
+++ b/src/admin_components/OrganizationEventsRequestTable.tsx
@@ -178,7 +178,7 @@ export default function AdminPage({ events, ITEMS_PER_PAGE }: AdminProps) {
           display: "flex",
           justifyContent: "left",
           boxSizing: "border-box",
-          width: "90rem",
+          width: "100%",
         }}
       >
         <table
@@ -187,6 +187,7 @@ export default function AdminPage({ events, ITEMS_PER_PAGE }: AdminProps) {
             borderCollapse: "collapse",
             borderSpacing: 0,
             borderBottom: "2px solid #f7f7f7",
+            width: "100%",
           }}
         >
           <thead>

--- a/src/pages/adminAccounts.tsx
+++ b/src/pages/adminAccounts.tsx
@@ -100,14 +100,17 @@ export default function AdminRequestTable() {
                         style={{ height: "0.35714rem", background: "#F07F2D" }}
                     ></div>
                     <h3>Requested Accounts</h3>
+
+                    {pendingUsers.length == 0 ? <p style={{textAlign: "center"}}>No Requests Yet</p> : 
                     <AccountsTable
                         ITEMS_PER_PAGE={4}
                         events={pendingUsers}
                         approveUser={approveUser}
                         declineUser={declineUser}
                         deleteUser={deleteUser}
-                    />
+                    />} 
                 </div>
+
                 {/* Approved Accounts */}
                 <div style={{ width: "90%" }}>
                     <h1 style={{ alignSelf: "flex-start" }}>Active Accounts</h1>
@@ -118,26 +121,31 @@ export default function AdminRequestTable() {
                         }}
                     ></div>
                     <h3>Approved Accounts</h3>
+
+                    {approvedUsers.length == 0 ? <p style={{textAlign: "center"}}>No Accounts Yet</p> : 
                     <AccountsTable
                         ITEMS_PER_PAGE={1}
                         events={approvedUsers}
                         approveUser={approveUser}
                         declineUser={declineUser}
                         deleteUser={deleteUser}
-                    />
+                    />}
+                    
                 </div>
 
                 {/* Declined Accounts */}
                 <div style={{ width: "90%" }}>
                     <h3>Declined Accounts</h3>
+                    
 
+                    {declinedUsers.length == 0 ? <p style={{textAlign: "center"}}>No Accounts Yet</p> : 
                     <AccountsTable
                         ITEMS_PER_PAGE={1}
                         events={declinedUsers}
                         approveUser={approveUser}
                         declineUser={declineUser}
                         deleteUser={deleteUser}
-                    />
+                    />}
                 </div>
             </div>
         </Layout>

--- a/src/pages/adminEvents.tsx
+++ b/src/pages/adminEvents.tsx
@@ -115,20 +115,21 @@ const deleteEvent = async (id: string) => {
     <Layout>
       {/* Requested Events */}
       <div style={styles.container}>
-        <div>
+        <div style={{ width: "90%" }}>
           <h1 style={{ alignSelf: "flex-start" }}>Inbox</h1>
           <div style={{ height: "0.35714rem", background: "#F07F2D" }}></div>
           <h3>Requested Events</h3>
+          {pending.length == 0 ? <p style={{textAlign: "center"}}>No Event Requests Yet</p> :
           <EventsTable 
               approveEvent={approveEvent}
               declineEvent={declineEvent}
               deleteEvent={deleteEvent}
               ITEMS_PER_PAGE={4} 
               events={pending} 
-          />
+          />}
         </div>
         {/* Approved Events */}
-        <div>
+        <div style={{ width: "90%" }}> 
           <h1 style={{ alignSelf: "flex-start" }}>Active events</h1>
           <div
             style={{
@@ -137,13 +138,14 @@ const deleteEvent = async (id: string) => {
             }}
           ></div>
           <h3>Approved Events</h3>
+          {approved.length == 0 ? <p style={{textAlign: "center"}}>No Events Yet</p> :
           <EventsTable 
               approveEvent={approveEvent}
               declineEvent={declineEvent}
               deleteEvent={deleteEvent}
               ITEMS_PER_PAGE={4} 
               events={approved} 
-          />
+          />}
         </div>
 
         {/* Postponed Events
@@ -158,18 +160,20 @@ const deleteEvent = async (id: string) => {
           />
         </div> */}
         {/* Declined Events */}
-        <div>
+        <div style={{ width: "90%" }}>
           <h3>Declined Events</h3>
+          {declined.length == 0 ? <p style={{textAlign: "center"}}>No Events Yet</p> :
           <EventsTable 
               approveEvent={approveEvent}
               declineEvent={declineEvent}
               deleteEvent={deleteEvent}
               ITEMS_PER_PAGE={4} 
               events={declined} 
-          />
+          />}
+          
         </div>
         {/* Past Events */}
-        <div>
+        <div style={{ width: "90%" }}>
           <h1 style={{ textAlign: "left" }}>Past events</h1>
           <div
             style={{
@@ -178,13 +182,14 @@ const deleteEvent = async (id: string) => {
             }}
           ></div>
           <h3>Archived</h3>
+          {archived.length == 0 ? <p style={{textAlign: "center"}}>No Past Events Yet</p> :
           <EventsTable 
               approveEvent={approveEvent}
               declineEvent={declineEvent}
               deleteEvent={deleteEvent}
               ITEMS_PER_PAGE={4} 
               events={archived} 
-          />
+          />}
         </div>
       </div>
     </Layout>

--- a/src/pages/organizationEvents.tsx
+++ b/src/pages/organizationEvents.tsx
@@ -90,14 +90,19 @@ export default function OrganizationEvents() {
     <Layout>
       {/* Requested Events */}
       <div style={styles.container}>
-        <div>
+        <div style={{ width: "90%"}}>
           <h1 style={{ alignSelf: "flex-start" }}>Outgoing Event Requests</h1>
           <div style={{ height: "0.35714rem", background: "#F07F2D" }}></div>
           <h3>Requested Events</h3>
-          <EventsTable ITEMS_PER_PAGE={4} events={pendingEvents} />
+          {pendingEvents.length == 0 ? <p style={{textAlign: "center"}}>No Events Yet</p> : 
+          <EventsTable 
+            ITEMS_PER_PAGE={4}
+            events={pendingEvents} 
+          />}
         </div>
+
         {/* Approved Events */}
-        <div>
+        <div style={{ width: "90%"}}>
           <h2 style={{ alignSelf: "flex-start" }}>Active events</h2>
           <div
             style={{
@@ -106,16 +111,25 @@ export default function OrganizationEvents() {
             }}
           ></div>
           <h3>Approved Events</h3>
-          <EventsTable ITEMS_PER_PAGE={1} events={approvedEvents} />
+          {approvedEvents.length == 0 ? <p style={{textAlign: "center"}}>No Events Yet</p> : 
+          <EventsTable 
+            ITEMS_PER_PAGE={3}
+            events={approvedEvents} 
+          />}
         </div>
 
         {/* Declined Events */}
-        <div>
+        <div style={{ width: "90%"}}>
           <h3>Declined Events</h3>
-          <EventsTable ITEMS_PER_PAGE={1} events={deniedEvents} />
+          {deniedEvents.length == 0 ? <p style={{textAlign: "center"}}>No Events Yet</p> : 
+          <EventsTable 
+            ITEMS_PER_PAGE={3}
+            events={deniedEvents} 
+          />}
         </div>
+
         {/* Past Events */}
-        <div>
+        <div style={{ width: "90%"}}>
           <h2 style={{ textAlign: "left" }}>Past events</h2>
           <div
             style={{
@@ -124,7 +138,11 @@ export default function OrganizationEvents() {
             }}
           ></div>
           <h3>Archived</h3>
-          <EventsTable ITEMS_PER_PAGE={3} events={pastEvents} />
+          {pastEvents.length == 0 ? <p style={{textAlign: "center"}}>No Events Yet</p> : 
+          <EventsTable 
+            ITEMS_PER_PAGE={3}
+            events={pastEvents} 
+          />}
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
## Developer: Lindsay Minami

Closes #120 

### Pull Request Summary

Add text to say that there are no accounts/events/requests yet

### Modifications

- adminAcounts.tsx (add text to say no accounts or requests yet in the various tables)
- adminEvents.tsx (add text to say no events or requests yet in the various tables)
- EventsRequestTable.tsx (fix format events table with text)

### Testing Considerations

- i think it's okay on resize (?)
- don't know if it's needed for all the tables but just added it just in case to be safe
- small but i just realized while i was writing this, the case in "Active _e_vents"/"Past _e_vents" vs "Active _A_ccounts"

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
<img width="1512" alt="Screenshot 2024-05-27 at 2 31 28 PM" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/20879552/caf8ec44-8838-47a9-bca0-b20cbad6fbf6">
<img width="1512" alt="Screenshot 2024-05-27 at 2 34 50 PM" src="https://github.com/hack4impact-calpoly/ecologistics-shared-calendar/assets/20879552/768ce759-0223-4abf-a1ea-328ab974b108">