### PR TITLE
fix: fixed the search bar... should be able to search up past events now

### DIFF
--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -86,6 +86,19 @@ useEffect(() => {
         console.error("Error fetching events:", error);
       });
   }, []);
+  // useEffect(() => {
+  //   fetch("/api/users/eventRoutes?status=Approved")
+  //     .then((res) => res.json())
+  //     .then((res) => {
+  //       convertEventDatesToDates(res.data as EventDocument[]);
+  //       setEvents(res.data as EventDocument[]);
+  //       setFutureEvents(filterFutureEvents(res.data as EventDocument[]));
+  //       setSelectedDateEvents(filterFutureEvents(res.data as EventDocument[])); // Initialize selectedDateEvents with future events
+  //     })
+  //     .catch((error) => {
+  //       console.error("Error fetching events:", error);
+  //     });
+  // }, []);
 
   const handleDateClick = (arg: { dateStr: string }) => {
     const clickedDate = new Date(arg.dateStr);
@@ -265,7 +278,8 @@ useEffect(() => {
           </button>
         )}
         {!isAddingEvent ? (
-          <EventBar events={selectedDateEvents.length > 0 ? selectedDateEvents : futureEvents} />
+          <EventBar events={selectedDateEvents.length > 0 ? selectedDateEvents : futureEvents} totalEvents ={events} />
+          
         ) : (
           <AddEventPanel
             onClose={() => setIsAddingEvent(false)}

--- a/src/pages/eventBar.tsx
+++ b/src/pages/eventBar.tsx
@@ -75,7 +75,7 @@ function Event(event: EventDocument) {
 }
 
 // Main EventBar Component
-export default function EventBar({ events }: { events: EventDocument[] }) {
+export default function EventBar({ events, totalEvents }: { events: EventDocument[], totalEvents: EventDocument[] }) {
   const styles = useEventBarStyles();
   const [windowHeight, setWindowHeight] = useState<number | null>(null);
   const [windowWidth, setWindowWidth] = useState<number | null>(null);
@@ -100,7 +100,7 @@ export default function EventBar({ events }: { events: EventDocument[] }) {
     const value = event.target.value;
     setSearchTerm(value);
     if (value) {
-      const filtered = (events || []).filter((event) =>
+      const filtered = (totalEvents || []).filter((event) =>
         event.title.toLowerCase().includes(value.toLowerCase())
       );
       setFilteredEvents(filtered);
@@ -112,12 +112,6 @@ export default function EventBar({ events }: { events: EventDocument[] }) {
   useEffect(() => {
     setFilteredEvents(events || []);
   }, [events]);
-
-  // const filterFutureEvents = (events: EventDocument[]) => {
-  //   const now = new Date();
-  //   console.log(now)
-  //   return events.filter(event => (new Date(event.startDate) >= now )&& (new Date(event.startDate).getTime >= now.getTime)).sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
-  // };
   
 
       

--- a/src/pages/publicCalendar.tsx
+++ b/src/pages/publicCalendar.tsx
@@ -281,7 +281,7 @@ export default function CalendarPage() {
         )}
         {!isAddingEvent ? (
           <EventBar
-            events={selectedDateEvents.length > 0 ? selectedDateEvents : futureEvents}
+            events={selectedDateEvents.length > 0 ? selectedDateEvents : futureEvents} totalEvents= {events}
           />
         ) : (
           <AddEventPanel


### PR DESCRIPTION
## Developer: {Full Name}

Closes #133 

### Pull Request Summary

For some reason, the search bar stopped being able to search up past events, so I fixed it so that past events can be searched.

### Modifications

I changed calendar.tsx and publicCalendar.tsx so that it passed the total events to the eventBar component. I changed the eventBar.tsx file so that the eventBar used the total events to handle the search instead of only the filtered ones.

### Testing Considerations

Maybe just double check that the search bar and the day click on the calendar will give the correct events.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
