### PR TITLE
173: fix: resolve infinite API calls on admin Event Management page

### DIFF
--- a/src/pages/adminEvents.tsx
+++ b/src/pages/adminEvents.tsx
@@ -2,7 +2,6 @@ import EventsTable from "../admin_components/EventsRequestTable";
 import Layout from "../components/layout";
 import React, { useState, useEffect } from "react";
 import axios from "axios";
-import { EventDocument } from "../database/eventSchema";
 
 // Interfaces for Event and API responses
 interface Event {
@@ -26,14 +25,13 @@ interface ApiResponse {
 }
 
 export default function AdminRequestTable() {
-  const [events, setEvents] = useState<EventDocument[]>([]);
   const [pending, setPending] = useState<Event[]>([]);
   const [approved, setApproved] = useState<Event[]>([]);
   const [postponed, setPostponed] = useState<Event[]>([]);
   const [declined, setDeclined] = useState<Event[]>([]);
   const [archived, setArchived] = useState<Event[]>([]);
 
-  useEffect(() => {
+  const fetchEvents = () => {
     fetch("/api/users/eventRoutes")
       .then((response) => response.json())
       .then((response: ApiResponse) => {
@@ -58,7 +56,11 @@ export default function AdminRequestTable() {
         );
       })
       .catch((error) => console.error("Failed to fetch events:", error));
-  });
+  };
+
+  useEffect(() => {
+    fetchEvents();
+  }, []);
 
   const approveEvent = async (id: string) => {
     /*
@@ -72,15 +74,6 @@ export default function AdminRequestTable() {
         status: "Approved",
         declineMessage: "",
       });
-
-      // Update the status in the user state variable
-      const updatedEvents = events.map((event) => {
-        if (event._id.toHexString() === id) {
-          return { ...event, deniedReason: "", status: "Approved" };
-        }
-        return event;
-      });
-      setEvents(updatedEvents);
 
       // send event accepted email to org
       const eventToAccept = response.data;
@@ -118,6 +111,8 @@ export default function AdminRequestTable() {
         .catch((error) => {
           console.error("Error:", error); // Handle error
         });
+
+      fetchEvents();
     } catch (err) {
       console.error(err);
     }
@@ -136,15 +131,6 @@ export default function AdminRequestTable() {
         status: "Denied",
         deniedReason: message,
       });
-      // Update the status in the user state variable
-      const updatedEvents = events.map((event) => {
-        if (event._id.toHexString() === id) {
-          return { ...event, deniedReason: message, status: "Denied" };
-        }
-        return event;
-      });
-      setEvents(updatedEvents);
-
       // send event accepted email to org
       const eventToAccept = response.data;
       // get org that created event
@@ -182,6 +168,8 @@ export default function AdminRequestTable() {
         .catch((error) => {
           console.error("Error:", error); // Handle error
         });
+
+      fetchEvents();
     } catch (err) {
       console.error(err);
     }
@@ -194,6 +182,7 @@ export default function AdminRequestTable() {
   */
     try {
       await axios.delete(`/api/admins/eventRoutes`, { data: { id } });
+      fetchEvents();
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## Developer: {Jeron Tre Perey}

Closes #{173}

### Pull Request Summary

Fixed infinite API calls on the Event Management admin page. The useEffect hook was missing a dependency array, causing it to re-run on every render and create an infinite fetch loop to /api/users/eventRoutes. Also cleaned up dead state and added proper re-fetching after approve, decline, and delete actions.

### Modifications

adminEvents.tsx
Removed unused EventDocument import
Removed dead events state that was never populated or rendered
Extracted fetch logic into a reusable fetchEvents() function
Added [] dependency array to useEffect (core fix)
Removed dead setEvents blocks in approveEvent and declineEvent
Added fetchEvents() calls after approve, decline, and delete mutations to update UI without manual refresh

### Testing Considerations

Navigate to Event Management page — only one GET /api/users/eventRoutes request should fire (two in dev due to React Strict Mode)
Approve a pending event → moves from "Requested Events" to "Active Events"
Decline a pending event → moves from "Requested Events" to "Declined Events"
Delete an event → disappears from its section
Each action should trigger exactly one re-fetch, not a continuous stream

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="723" height="423" alt="image" src="https://github.com/user-attachments/assets/43736df5-cdc2-4d40-ac45-535692329a89" />