### PR TITLE
Update admin event creation to bypass pending

### DIFF
--- a/src/components/addEventPanel.tsx
+++ b/src/components/addEventPanel.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import { Select, MenuItem, FormControl, InputLabel } from "@mui/material";
 import { stat } from "fs";
 
+
 interface AddEventForm {
   //organization: string;
   title: string;
@@ -210,7 +211,7 @@ export default function AddEventPanel({
           description: formData.description,
           isVirtual: formData.isVirtual,
           location: address,
-          status: user?.publicMetadata?.role === "admin" ? "Approved" : "Pending",
+          status: user.publicMetadata.role === "admin" ? "Approved" : "Pending",
           imageLink: uploadResult?.URL,
         };
 

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -12,10 +12,11 @@ import AddEventPanel from "../components/addEventPanel";
 import EventRequestPopup from "../components/eventRequestPopup";
 import style1 from "../styles/calendar.module.css";
 import { useClerk } from "@clerk/clerk-react";
-import { EventDocument } from "database/eventSchema";
+import { EventDocument } from "../database/eventSchema";
 import { useRouter } from "next/router";
 import { convertEventDatesToDates } from "../utils/events";
 import { DateTime } from "luxon";
+import { useUser } from "@clerk/clerk-react";
 
 // Recurring because events may span multiple days.
 // This still works for single-day events.
@@ -31,6 +32,7 @@ export interface Event {
 }
 
 export default function CalendarPage() {
+  const { user } = useUser();
   const [events, setEvents] = useState<EventDocument[]>([]);
   const [futureEvents, setFutureEvents] = useState<EventDocument[]>([]);
   const [calendarEvents, setCalendarEvents] = useState<FullCalenderRecurringEvent[]>([]);
@@ -213,7 +215,7 @@ useEffect(() => {
 
   return (
     <Layout>
-      {isShowingEventPopUp && (
+      {isShowingEventPopUp && user.publicMetadata.role != "admin" &&  (
         <EventRequestPopup onClose={() => setIsShowingEventPopUp(false)} />
       )}
       <div className={style1.calendarPageContainer} ref={calendarRef}>

--- a/src/pages/publicCalendar.tsx
+++ b/src/pages/publicCalendar.tsx
@@ -18,6 +18,7 @@ import { useRouter } from "next/router";
 import { convertEventDatesToDates } from "../utils/events";
 import { DateTime } from "luxon";
 import { useSession } from "@clerk/nextjs";
+import { useUser } from "@clerk/clerk-react";
 
 // Recurring because events may span multiple days.
 // This still works for single-day events.
@@ -33,6 +34,7 @@ export interface Event {
 }
 
 export default function CalendarPage() {
+    const { user } = useUser();
     const [events, setEvents] = useState<EventDocument[]>([]);
     const [calendarEvents, setCalendarEvents] = useState<
         FullCalenderRecurringEvent[]
@@ -245,7 +247,7 @@ export default function CalendarPage() {
 
     return (
         <Layout>
-            {isShowingEventPopUp && (
+            {isShowingEventPopUp && user.publicMetadata.role != "admin" && (
                 <EventRequestPopup
                     onClose={() => setIsShowingEventPopUp(false)}
                 />


### PR DESCRIPTION
## Developer: Ethan Yang

Closes #170 

### Pull Request Summary

Updated event creation to bypass the pending stage for admin users. Status is now conditional to bypass admins straight to approved instead of pending.

### Modifications

addEventPanel.tsx:
- Modified the referenced chunk of code in the issue to have a conditional status function for admins and non-admins.

### Testing Considerations

Looked up existing standards for status and role names, but was not able to test, as I was not sure how to test as an admin. 

### Pull Request Checklist

- [✅] Code is neat, readable, and works
- [✅] Comments are appropriate
- [✅] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [✅] The developer name is specified
- [✅] The summary is completed
- [✅] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
<img width="693" height="219" alt="Screenshot 2026-02-08 at 12 19 46 AM" src="https://github.com/user-attachments/assets/cb3c71d8-1e53-43bf-a473-a0cbb757e480" />
