### PR TITLE
195 - Various QOL Changes

### DIFF
--- a/src/components/addEventLocationPanel.tsx
+++ b/src/components/addEventLocationPanel.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { useState } from "react";
+import { MdArrowBack } from "react-icons/md";
+import { MdClose } from "react-icons/md";
 import { AddressAutoFill } from "./addressAutofill";
 import MapPin from "./mapPin";
 import { AddEventFormType } from "./addEventPanel";
@@ -10,6 +12,8 @@ type InPersonMethod = "pin" | "search";
 const geoKey = process.env.GEOAPIFY_API_KEY!;
 
 type AddEventLocationPanelProps = {
+  onBack: () => void;
+  onClose: () => void;
   onContinue: () => void;
   setEventFormData: React.Dispatch<React.SetStateAction<AddEventFormType>>;
   eventFormData: AddEventFormType;
@@ -17,6 +21,8 @@ type AddEventLocationPanelProps = {
 };
 
 export default function AddEventLocationPanel({
+  onBack,
+  onClose,
   onContinue,
   setEventFormData,
   eventFormData,
@@ -44,6 +50,8 @@ export default function AddEventLocationPanel({
 
   return (
     <div style={styles.container}>
+      <MdArrowBack onClick={onBack} style={styles.back} size={25} />
+      <MdClose onClick={onClose} style={styles.close} size={25} />
       <h2 style={styles.header}>Create New Event</h2>
       <p style={styles.subHeader}>Where will this event take place?</p>
 
@@ -178,11 +186,13 @@ export default function AddEventLocationPanel({
           }
         />
       )}
-      {error && <p style={styles.error}>{error}</p>}
+      <div style={styles.errorBox}>{error && <p style={styles.error}>{error}</p>}</div>
 
-      <button style={styles.button} type="button" onClick={onContinue}>
-        Continue
-      </button>
+      <div style={styles.actions}>
+        <button style={styles.button} type="button" onClick={onContinue}>
+          Continue
+        </button>
+      </div>
     </div>
   );
 }
@@ -194,29 +204,28 @@ const styles: { [key: string]: React.CSSProperties } = {
     alignContent: "center",
     justifyContent: "center",
     boxSizing: "border-box",
-    borderRadius: "10px",
+    borderRadius: "0.625rem",
     border: "1px solid black",
     boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
-    padding: "20px",
-    margin: "10px",
+    padding: "1.25rem",
+    margin: "0.625rem",
     width: "80%",
     height: "50%",
     position: "relative",
-    gap: "5px",
+    gap: "0.3125rem",
   },
-    button: {
-    padding: "10px 15px",
+  button: {
+    padding: "0.625rem 0.9375rem",
     border: "none",
-    borderRadius: "20px",
+    borderRadius: "1.25rem",
     background: "#335543",
     color: "white",
     cursor: "pointer",
     display: "block",
-    width: "15%",
-    alignSelf: "center",
+    minWidth: "7.5rem",
   },
   header: {
-    margin: 0,
+    margin: "1.25rem 0 0 0",
   },
   subHeader: {
     color: "#333",
@@ -225,17 +234,17 @@ const styles: { [key: string]: React.CSSProperties } = {
     display: "flex",
     background: "#bdbdbd",
     borderRadius: "999px",
-    padding: "4px",
+    padding: "0.25rem",
   },
   methodContainer: {
     display: "flex",
-    gap: "12px",
+    gap: "0.75rem",
   },
   modeButton: {
     flex: 1,
     border: "none",
     background: "transparent",
-    padding: "10px",
+    padding: "0.625rem",
     borderRadius: "999px",
     cursor: "pointer",
     fontWeight: 500,
@@ -243,7 +252,7 @@ const styles: { [key: string]: React.CSSProperties } = {
   activeModeButton: {
     flex: 1,
     border: "none",
-    padding: "10px",
+    padding: "0.625rem",
     borderRadius: "999px",
     cursor: "pointer",
     fontWeight: 500,
@@ -252,8 +261,8 @@ const styles: { [key: string]: React.CSSProperties } = {
   },
   methodButton: {
     flex: 1,
-    padding: "20px",
-    borderRadius: "12px",
+    padding: "1.25rem",
+    borderRadius: "0.75rem",
     background: "#f0f0f0",
     textAlign: "center",
     cursor: "pointer",
@@ -261,8 +270,8 @@ const styles: { [key: string]: React.CSSProperties } = {
   },
   activeMethodButton: {
     flex: 1,
-    padding: "20px",
-    borderRadius: "12px",
+    padding: "1.25rem",
+    borderRadius: "0.75rem",
     textAlign: "center",
     cursor: "pointer",
     background: "#b0b0b0",
@@ -270,8 +279,8 @@ const styles: { [key: string]: React.CSSProperties } = {
   },
   input: {
     width: "calc(100% - 20px)",
-    padding: "10px",
-    borderRadius: "15px",
+    padding: "0.625rem",
+    borderRadius: "0.9375rem",
     background: "rgba(217, 217, 217, 0.3)",
     border: "1px solid #989898",
     color: "black",
@@ -279,5 +288,31 @@ const styles: { [key: string]: React.CSSProperties } = {
   error: {
     color: "red",
     alignSelf: "center",
+    margin: 0,
+    fontSize: "1rem",
+  },
+  errorBox: {
+    minHeight: "1.25rem",
+    display: "flex",
+    justifyContent: "center",
+  },
+  actions: {
+    display: "flex",
+    justifyContent: "center",
+    gap: "0.75rem",
+  },
+  close: {
+    position: "absolute",
+    top: "0.5rem",
+    right: "0",
+    margin: "0.3125rem",
+    cursor: "pointer",
+  },
+  back: {
+    position: "absolute",
+    top: "0.5rem",
+    left: "0",
+    margin: "0.3125rem",
+    cursor: "pointer",
   },
 };

--- a/src/components/addEventLocationPanel.tsx
+++ b/src/components/addEventLocationPanel.tsx
@@ -10,23 +10,37 @@ type InPersonMethod = "pin" | "search";
 const geoKey = process.env.GEOAPIFY_API_KEY!;
 
 type AddEventLocationPanelProps = {
-  setPanelType: (panel: "start" | "location" | "misc") => void;
+  onContinue: () => void;
   setEventFormData: React.Dispatch<React.SetStateAction<AddEventFormType>>;
   eventFormData: AddEventFormType;
+  error?: string;
 };
 
 export default function AddEventLocationPanel({
-  setPanelType,
+  onContinue,
   setEventFormData,
-  eventFormData
+  eventFormData,
+  error,
 }: AddEventLocationPanelProps) {
-  const [mode, setMode] = useState<LocationMode>("in-person"); //active mode
+  const [mode, setMode] = useState<LocationMode>(
+    eventFormData.mode === "virtual" ? "virtual" : "in-person",
+  ); //active mode
   const [method, setMethod] = useState<InPersonMethod>("pin"); //active method
   const [formData, setFormData] = useState({
     lon: 0,
     lat: 0,
     desc: "",
   });
+
+  // Keep the parent state in sync so validation can run in one place.
+  const setLocationMode = (nextMode: LocationMode) => {
+    setMode(nextMode);
+    setEventFormData((prev) => ({
+      ...prev,
+      mode: nextMode,
+      isVirtual: nextMode === "virtual",
+    }));
+  };
 
   return (
     <div style={styles.container}>
@@ -39,7 +53,7 @@ export default function AddEventLocationPanel({
           style={
             mode === "in-person" ? styles.activeModeButton : styles.modeButton
           }
-          onClick={() => setMode("in-person")}
+          onClick={() => setLocationMode("in-person")}
         >
           In Person
         </button>
@@ -47,7 +61,7 @@ export default function AddEventLocationPanel({
           style={
             mode === "virtual" ? styles.activeModeButton : styles.modeButton
           }
-          onClick={() => setMode("virtual")}
+          onClick={() => setLocationMode("virtual")}
         >
           Virtual
         </button>
@@ -99,6 +113,13 @@ export default function AddEventLocationPanel({
               inLat={formData.lat}
               onPickAddress={(data) => {
                 setFormData({ ...formData, lon: data.lon, lat: data.lat });
+                setEventFormData((prev) => ({
+                  ...prev,
+                  mode: "in-person",
+                  isVirtual: false,
+                  latitude: data.lat,
+                  longitude: data.lon,
+                }));
               }}
             />
           </div>
@@ -106,7 +127,15 @@ export default function AddEventLocationPanel({
           <input
             type="text"
             style={styles.input}
-            onChange={(e) => setFormData({ ...formData, desc: e.target.value })}
+            onChange={(e) => {
+              setFormData({ ...formData, desc: e.target.value });
+              setEventFormData((prev) => ({
+                ...prev,
+                mode: "in-person",
+                isVirtual: false,
+                locationDescription: e.target.value,
+              }));
+            }}
             value={formData.desc}
             placeholder="Add description of location (optional)"
           />
@@ -118,17 +147,40 @@ export default function AddEventLocationPanel({
             apiKey={process.env.NEXT_PUBLIC_GEOAPIFY_API_KEY as string}
             onSelect={(data, feature) => {
               setFormData({ ...formData, lon: data.lon, lat: data.lat });
-              setEventFormData({...eventFormData,
+              setEventFormData((prev) => ({
+                  ...prev,
                   street: (feature.properties.street ?? "") as string,
                   city: (feature.properties.city ?? "") as string,
                   state: (feature.properties.state_code ?? "") as string,
                   postalCode: (feature.properties.postcode ?? "") as string,
-                  mode: mode});
+                  latitude: data.lat,
+                  longitude: data.lon,
+                  mode: mode,
+                  isVirtual: false,
+              }));
             }}
           />
         </div>
       )}
-      <button style={styles.button} type="button" onClick={() => setPanelType('misc')}>
+      {mode === "virtual" && (
+        <input
+          type="url"
+          style={styles.input}
+          placeholder="Meeting link"
+          value={eventFormData.url ?? ""}
+          onChange={(e) =>
+            setEventFormData((prev) => ({
+              ...prev,
+              mode: "virtual",
+              isVirtual: true,
+              url: e.target.value,
+            }))
+          }
+        />
+      )}
+      {error && <p style={styles.error}>{error}</p>}
+
+      <button style={styles.button} type="button" onClick={onContinue}>
         Continue
       </button>
     </div>
@@ -223,5 +275,9 @@ const styles: { [key: string]: React.CSSProperties } = {
     background: "rgba(217, 217, 217, 0.3)",
     border: "1px solid #989898",
     color: "black",
+  },
+  error: {
+    color: "red",
+    alignSelf: "center",
   },
 };

--- a/src/components/addEventMisc.tsx
+++ b/src/components/addEventMisc.tsx
@@ -1,13 +1,21 @@
 import React, { useState } from "react";
+import { MdArrowBack } from "react-icons/md";
+import { MdClose } from "react-icons/md";
 import { MdOutlineFileUpload } from "react-icons/md";
 import { useDropzone } from "react-dropzone";
 import Image from "next/image";
 
 type AddEventMiscProps = {
+  onBack: () => void;
+  onClose: () => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
 };
 
-export default function AddEventMisc({ onSubmit }: AddEventMiscProps) {
+export default function AddEventMisc({
+  onBack,
+  onClose,
+  onSubmit,
+}: AddEventMiscProps) {
   const [details, setDetails] = useState("");
   const [photo, setPhoto] = useState<File | null>(null);
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null);
@@ -25,7 +33,9 @@ export default function AddEventMisc({ onSubmit }: AddEventMiscProps) {
 
   return (
     <form onSubmit={onSubmit} style={styles.container}>
-      <h3>Create New Event</h3>
+      <MdArrowBack onClick={onBack} style={styles.back} size={25} />
+      <MdClose onClick={onClose} style={styles.close} size={25} />
+      <h3 style={styles.title}>Create New Event</h3>
 
       <h4>Additional Details</h4>
       <textarea
@@ -58,9 +68,11 @@ export default function AddEventMisc({ onSubmit }: AddEventMiscProps) {
         )}
       </div>
 
-      <button type="submit" style={styles.button}>
-        Submit
-      </button>
+      <div style={styles.actions}>
+        <button type="submit" style={styles.button}>
+          Submit
+        </button>
+      </div>
     </form>
   );
 }
@@ -72,42 +84,63 @@ const styles: { [key: string]: React.CSSProperties } = {
     alignContent: "center",
     justifyContent: "center",
     boxSizing: "border-box",
-    borderRadius: "10px",
+    borderRadius: "0.625rem",
     border: "1px solid black",
     boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
-    padding: "20px",
-    margin: "10px",
+    padding: "1.25rem",
+    margin: "0.625rem",
     width: "80%",
     height: "50%",
     position: "relative",
-    gap: "5px",
+    gap: "0.3125rem",
   },
   textarea: {
     width: "100%",
     minHeight: "100px",
-    padding: "10px",
-    borderRadius: "10px",
+    padding: "0.625rem",
+    borderRadius: "0.625rem",
     border: "1px solid #989898",
   },
   uploadContainer: {
     textAlign: "center",
-    padding: "40px",
+    padding: "2.5rem",
     border: "1px dashed #000",
-    borderRadius: "5px",
+    borderRadius: "0.3125rem",
   },
   uploadButton: {
     cursor: "pointer",
     display: "block",
     marginBottom: "8px",
   },
+  title: {
+    marginTop: "1.25rem",
+  },
   button: {
-    padding: "10px 15px",
-    borderRadius: "20px",
+    padding: "0.625rem 0.9375rem",
+    borderRadius: "1.25rem",
     border: "none",
     background: "#335543",
     color: "white",
     cursor: "pointer",
-    width: "120px",
-    alignSelf: "center",
+    width: "7.5rem",
+  },
+  actions: {
+    display: "flex",
+    justifyContent: "center",
+    gap: "0.75rem",
+  },
+  close: {
+    position: "absolute",
+    top: "0.5rem",
+    right: "0",
+    margin: "0.3125rem",
+    cursor: "pointer",
+  },
+  back: {
+    position: "absolute",
+    top: "0.5rem",
+    left: "0",
+    margin: "0.3125rem",
+    cursor: "pointer",
   },
 };

--- a/src/components/addEventPanel.tsx
+++ b/src/components/addEventPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { MdArrowBack } from "react-icons/md";
 import { MdClose } from "react-icons/md";
 import axios from "axios";
 import { useUser } from "@clerk/clerk-react";
@@ -219,6 +220,11 @@ export default function AddEventPanel({
     setPanelType("misc");
   };
 
+  const handleBack = (panel: Panel) => {
+    setFormErrors({});
+    setPanelType(panel);
+  };
+
   const onEventAdd = async (e: React.FormEvent) => {
     e?.preventDefault();
     onCreate();
@@ -421,6 +427,7 @@ export default function AddEventPanel({
     <>
       {panelType === "start" && (
         <form style={styles.container} onSubmit={onEventAdd}>
+          <MdArrowBack onClick={onClose} style={styles.back} size={25} />
           <MdClose onClick={onClose} style={styles.close} size={25} />
           <h3 style={styles.title}>Add Event</h3>
           <h4 style={styles.inputTitle}>
@@ -444,11 +451,9 @@ export default function AddEventPanel({
           <p style={styles.characterCount}>
             Characters Typed: {titleCharsTyped}/45
           </p>
-          {formErrors.title && (
-            <div style={styles.errorBox}>
-              <p style={styles.error}>{formErrors.title}</p>
-            </div>
-          )}
+          <div style={styles.errorBox}>
+            {formErrors.title && <p style={styles.error}>{formErrors.title}</p>}
+          </div>
 
           <div style={styles.horizontal}>
             <div style={styles.inputContainer}>
@@ -525,11 +530,9 @@ export default function AddEventPanel({
             </div>
           </div>
 
-          {formErrors.dates && (
-            <div style={styles.errorBox}>
-              <p style={styles.error}>{formErrors.dates}</p>
-            </div>
-          )}
+          <div style={styles.errorBox}>
+            {formErrors.dates && <p style={styles.error}>{formErrors.dates}</p>}
+          </div>
 
           <h4 style={styles.inputTitle}>Description</h4>
           <textarea
@@ -564,12 +567,20 @@ export default function AddEventPanel({
       {panelType === "location" && (
         <AddEventLocationPanel
           error={formErrors.location}
+          onBack={() => handleBack("start")}
+          onClose={onClose}
           onContinue={handleLocationContinue}
           eventFormData={formData}
           setEventFormData={setFormData}
         />
       )}
-      {panelType === "misc" && <AddEventMisc onSubmit={onEventAdd} />}
+      {panelType === "misc" && (
+        <AddEventMisc
+          onBack={() => handleBack("location")}
+          onClose={onClose}
+          onSubmit={onEventAdd}
+        />
+      )}
     </>
   );
 }
@@ -581,20 +592,20 @@ const styles: { [key: string]: React.CSSProperties } = {
     alignContent: "center",
     justifyContent: "center",
     boxSizing: "border-box",
-    borderRadius: "10px",
+    borderRadius: "0.625rem",
     border: "1px solid black",
     boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
-    padding: "20px",
-    margin: "10px",
+    padding: "1.25rem",
+    margin: "0.625rem",
     width: "80%",
     height: "50%",
     position: "relative",
-    gap: "5px",
+    gap: "0.3125rem",
   },
   input: {
     width: "calc(100% - 20px)",
-    padding: "10px",
-    borderRadius: "15px",
+    padding: "0.625rem",
+    borderRadius: "0.9375rem",
     background: "rgba(217, 217, 217, 0.3)",
     border: "1px solid #989898",
     color: "black",
@@ -602,8 +613,8 @@ const styles: { [key: string]: React.CSSProperties } = {
   textarea: {
     width: "calc(100% - 20px)",
     minHeight: "100px",
-    padding: "10px",
-    borderRadius: "15px",
+    padding: "0.625rem",
+    borderRadius: "0.9375rem",
     background: "rgba(217, 217, 217, 0.3)",
     border: "1px solid #989898",
     color: "black",
@@ -619,9 +630,9 @@ const styles: { [key: string]: React.CSSProperties } = {
     accentColor: "black",
   },
   button: {
-    padding: "10px 15px",
+    padding: "0.625rem 0.9375rem",
     border: "none",
-    borderRadius: "20px",
+    borderRadius: "1.25rem",
     background: "#335543",
     color: "white",
     cursor: "pointer",
@@ -630,11 +641,11 @@ const styles: { [key: string]: React.CSSProperties } = {
     alignSelf: "center",
   },
   uploadContainer: {
-    marginTop: "10px",
+    marginTop: "0.625rem",
     textAlign: "center",
-    padding: "40px",
+    padding: "2.5rem",
     border: "1px dashed #000",
-    borderRadius: "5px",
+    borderRadius: "0.3125rem",
   },
   uploadButton: {
     cursor: "pointer",
@@ -647,7 +658,7 @@ const styles: { [key: string]: React.CSSProperties } = {
     display: "flex",
     flexDirection: "row",
     justifyContent: "space-around",
-    gap: "5px",
+    gap: "0.3125rem",
   },
   inputContainer: {
     display: "flex",
@@ -658,21 +669,33 @@ const styles: { [key: string]: React.CSSProperties } = {
   inputTitle: {
     fontWeight: "bold",
   },
+  title: {
+    marginTop: "1.25rem",
+  },
   close: {
     position: "absolute",
-    top: "0",
+    top: "0.5rem",
+    right: "0",
+    margin: "0.3125rem",
+    cursor: "pointer",
+  },
+  back: {
+    position: "absolute",
+    top: "0.5rem",
     left: "0",
-    margin: "5px",
+    margin: "0.3125rem",
     cursor: "pointer",
   },
   error: {
     color: "red",
-    marginTop: "5px",
+    margin: 0,
+    fontSize: "1rem",
   },
   errorBox: {
     display: "flex",
     alignContent: "center",
     justifyContent: "center",
+    minHeight: "1.25rem",
   },
   characterCount: {
     color: "grey",

--- a/src/components/addEventPanel.tsx
+++ b/src/components/addEventPanel.tsx
@@ -21,6 +21,9 @@ export interface AddEventFormType {
   street: string;
   state: string;
   postalCode: string;
+  latitude: number | null;
+  longitude: number | null;
+  locationDescription: string;
 }
 
 interface FormErrors {
@@ -40,7 +43,7 @@ const EMPTY_FORM = {
   startTime: "",
   endTime: "",
   description: "",
-  mode: "",
+  mode: "in-person",
   isVirtual: false,
   url: null,
   photo: null,
@@ -48,6 +51,9 @@ const EMPTY_FORM = {
   street: "",
   state: "",
   postalCode: "",
+  latitude: null,
+  longitude: null,
+  locationDescription: "",
 };
 
 interface Event {
@@ -117,15 +123,23 @@ export default function AddEventPanel({
   // Keep location rules separate so each panel can block progression
   const getLocationPanelErrors = (): Partial<FormErrors> => {
     const errors = {} as Partial<FormErrors>;
+    const hasStructuredAddress =
+      hasText(formData.street) &&
+      hasText(formData.city) &&
+      hasText(formData.state) &&
+      hasText(formData.postalCode);
+    const hasPinnedLocation =
+      hasText(formData.locationDescription) ||
+      (formData.latitude !== null &&
+        formData.longitude !== null &&
+        (formData.latitude !== 0 || formData.longitude !== 0));
 
     if (
       formData.mode === "in-person" &&
-      (!hasText(formData.street) ||
-        !hasText(formData.city) ||
-        !hasText(formData.state) ||
-        !hasText(formData.postalCode))
+      !hasStructuredAddress &&
+      !hasPinnedLocation
     ) {
-      errors.location = "Address is required.";
+      errors.location = "Location is required.";
     } else if (formData.mode === "virtual" && !hasText(formData.url)) {
       errors.location = "Meeting link is required.";
     }
@@ -176,6 +190,35 @@ export default function AddEventPanel({
     return errors;
   };
 
+  // Continue buttons validate their own panel before changing steps.
+  const handleStartContinue = () => {
+    const errors = getErrorsForEmptyFields(["start"]);
+
+    if (Object.keys(errors).length === 0) {
+      addDateErrors(errors);
+    }
+
+    if (Object.keys(errors).length !== 0) {
+      setFormErrors(errors);
+      return;
+    }
+
+    setFormErrors({});
+    setPanelType("location");
+  };
+
+  const handleLocationContinue = () => {
+    const errors = getErrorsForEmptyFields(["location"]);
+
+    if (Object.keys(errors).length !== 0) {
+      setFormErrors(errors);
+      return;
+    }
+
+    setFormErrors({});
+    setPanelType("misc");
+  };
+
   const onEventAdd = async (e: React.FormEvent) => {
     e?.preventDefault();
     onCreate();
@@ -206,7 +249,18 @@ export default function AddEventPanel({
         let address = formData.url || "";
 
         if (formData.mode == "in-person") {
+          const hasStructuredAddress =
+            hasText(formData.street) &&
+            hasText(formData.city) &&
+            hasText(formData.state) &&
+            hasText(formData.postalCode);
+
           address = `${formData.street}, ${formData.city}, ${formData.state}, ${formData.postalCode}`;
+          if (!hasStructuredAddress) {
+            address =
+              formData.locationDescription.trim() ||
+              `${formData.latitude}, ${formData.longitude}`;
+          }
         }
 
         const event: Event = {
@@ -390,6 +444,11 @@ export default function AddEventPanel({
           <p style={styles.characterCount}>
             Characters Typed: {titleCharsTyped}/45
           </p>
+          {formErrors.title && (
+            <div style={styles.errorBox}>
+              <p style={styles.error}>{formErrors.title}</p>
+            </div>
+          )}
 
           <div style={styles.horizontal}>
             <div style={styles.inputContainer}>
@@ -496,7 +555,7 @@ export default function AddEventPanel({
             style={styles.button}
             type="button"
             disabled={isLoading}
-            onClick={() => setPanelType("location")}
+            onClick={handleStartContinue}
           >
             {isLoading ? "Loading..." : "Continue"}
           </button>
@@ -504,7 +563,8 @@ export default function AddEventPanel({
       )}
       {panelType === "location" && (
         <AddEventLocationPanel
-          setPanelType={setPanelType}
+          error={formErrors.location}
+          onContinue={handleLocationContinue}
           eventFormData={formData}
           setEventFormData={setFormData}
         />

--- a/src/components/addEventPanel.tsx
+++ b/src/components/addEventPanel.tsx
@@ -90,34 +90,61 @@ export default function AddEventPanel({
   const [desCharsTyped, setDesCharsTyped] = useState(0);
   const [panelType, setPanelType] = useState<Panel>("start");
 
-  const getErrorsForEmptyFields = (): Partial<FormErrors> => {
+  const hasText = (value: string | null | undefined) =>
+    Boolean(value && value.trim());
+
+  // Validate only the fields shown on the first panel
+  const getStartPanelErrors = (): Partial<FormErrors> => {
     const errors = {} as Partial<FormErrors>;
 
-    const fieldsToCheck = [
-      { field: "title", error: "Title is required." },
-      { field: "dates", error: "Start date is required." },
-      { field: "dates", error: "Start time is required." },
-      { field: "dates", error: "End date is required." },
-      { field: "dates", error: "End time is required." },
-      //{ field: "description", error: "Description is required." },
-      { field: "location", error: "Link or address is required." },
-      //{ field: "photo",isFile: true },
-    ];
+    if (!hasText(formData.title)) {
+      errors.title = "Title is required.";
+    }
 
-    const fieldKeyToErrorKey = (field: string) => {
-      if (field.includes("Date") || field.includes("Time")) return "dates";
-      return field;
-    };
+    if (!hasText(formData.startDate)) {
+      errors.dates = "Start date is required.";
+    } else if (!hasText(formData.startTime)) {
+      errors.dates = "Start time is required.";
+    } else if (!hasText(formData.endDate)) {
+      errors.dates = "End date is required.";
+    } else if (!hasText(formData.endTime)) {
+      errors.dates = "End time is required.";
+    }
 
-    fieldsToCheck.forEach(({ field, error /*isFile*/ }) => {
-      // const key = field as keyof typeof formData;
-      // if (
-      //   (isFile && formData[key] === null) ||
-      //   (!isFile && formData[key] === "")
-      // ) {
-      //   errors[fieldKeyToErrorKey(key) as keyof FormErrors] = error;
-      // }
-    });
+    return errors;
+  };
+
+  // Keep location rules separate so each panel can block progression
+  const getLocationPanelErrors = (): Partial<FormErrors> => {
+    const errors = {} as Partial<FormErrors>;
+
+    if (
+      formData.mode === "in-person" &&
+      (!hasText(formData.street) ||
+        !hasText(formData.city) ||
+        !hasText(formData.state) ||
+        !hasText(formData.postalCode))
+    ) {
+      errors.location = "Address is required.";
+    } else if (formData.mode === "virtual" && !hasText(formData.url)) {
+      errors.location = "Meeting link is required.";
+    }
+
+    return errors;
+  };
+
+  const getErrorsForEmptyFields = (
+    panels: Panel[] = panelType === "misc" ? [] : [panelType],
+  ): Partial<FormErrors> => {
+    const errors = {} as Partial<FormErrors>;
+
+    if (panels.includes("start")) {
+      Object.assign(errors, getStartPanelErrors());
+    }
+
+    if (panels.includes("location")) {
+      Object.assign(errors, getLocationPanelErrors());
+    }
 
     return errors;
   };

--- a/src/components/addressAutofill.tsx
+++ b/src/components/addressAutofill.tsx
@@ -85,8 +85,6 @@ export function AddressAutoFill({
   const [items, setItems] = useState<GeoapifyFeature[]>([]);
   const [dropOpen, setDropOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [selectedAddress, setSelectedAddress] =
-    useState<SelectedAddress | null>(null);
   const skipNextFetchRef = useRef(false);
 
   //Close dropdown if clicked outside
@@ -143,7 +141,6 @@ export function AddressAutoFill({
   const hasResults = items.length > 0;
   function choose(feature: GeoapifyFeature) {
     const [lon, lat] = feature.geometry.coordinates;
-    setSelectedAddress({ lat, lon });
     skipNextFetchRef.current = true;
     setInput(feature.properties.formatted);
     setDropOpen(false);
@@ -191,13 +188,6 @@ export function AddressAutoFill({
               </button>
             ))
           )}
-        </div>
-      )}
-      {selectedAddress && (
-        <div style={{ marginTop: "8px" }}>
-          <strong>Selected Address:</strong>
-          <div>Lat: {selectedAddress?.lat}</div>
-          <div>Lon: {selectedAddress?.lon}</div>
         </div>
       )}
     </div>

--- a/src/components/mapPin.tsx
+++ b/src/components/mapPin.tsx
@@ -198,8 +198,14 @@ export default function MapPin({ inLon, inLat, onPickAddress }: MapPinProps) {
     <div>
       <div>{loading ? " (Loading...)" : ""}</div>
 
-      <div ref={toolbarRef} style={{ width: 384, height: 20 }} />
-      <div ref={mapDivRef} style={{ width: 384, height: 384 }} />
+      <div style={{ position: "relative", width: "24rem", height: "24rem" }}>
+        {/* Keep controls inside the map so they don't cover panel */}
+        <div
+          ref={toolbarRef}
+          style={{ position: "absolute", top: "0.5rem", left: "0.5rem", zIndex: 1 }}
+        />
+        <div ref={mapDivRef} style={{ width: "24rem", height: "24rem" }} />
+      </div>
     </div>
   );
 }

--- a/src/components/mapPin.tsx
+++ b/src/components/mapPin.tsx
@@ -77,20 +77,20 @@ export default function MapPin({ inLon, inLat, onPickAddress }: MapPinProps) {
 
     setLoading(true);
     if (inLon == 0 || inLat == 0) {
-      const watchId = navigator.geolocation.getCurrentPosition(
+      navigator.geolocation.getCurrentPosition(
         (position) => {
-          setPinCoords({
+          const nextCoords = {
             lon: position.coords.longitude,
             lat: position.coords.latitude,
-          });
+          };
+
+          setPinCoords(nextCoords);
+          onPickAddress?.(nextCoords);
         },
         (error) => {
           console.error("Error getting position:", error);
         },
       );
-      if(onPickAddress) {
-        onPickAddress({ lon: pinCoords.lon , lat: pinCoords.lat });
-      }
       setLoading(false);
     } else {
       setPinCoords({ lon: inLon, lat: inLat });

--- a/src/styles/calendar.module.css
+++ b/src/styles/calendar.module.css
@@ -1,7 +1,7 @@
 .calendarPageContainer {
   display: flex;
   flex-direction: column;
-  justify-content: start;
+  justify-content: flex-start;
   padding: 0px;
   margin: 0px;
   white-space: nowrap;

--- a/src/styles/calendar.module.css
+++ b/src/styles/calendar.module.css
@@ -2,8 +2,8 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  padding: 0px;
-  margin: 0px;
+  padding: 0;
+  margin: 0;
   white-space: nowrap;
 }
 
@@ -17,8 +17,8 @@
   text-align: center;
   background: #f7ab74;
   border-radius: 0.75rem;
-  border: 0px;
-  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+  border: 0;
+  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
   cursor: pointer;
   margin-left: 1rem;
 }
@@ -44,15 +44,15 @@
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
-    padding: 0px;
-    margin: 0px;
+    padding: 0;
+    margin: 0;
     white-space: nowrap;
   }
 }
 @media (orientation:landscape) and (min-width: 786px) {
   .addButton {
-    display: block; /* or flex, depending on your layout */
-    width: 50%; /* Example to make it full width under the calendar */
-    margin-top: 20px; /* Space between the calendar and the button */
+    display: block;
+    width: 50%;
+    margin-top: 20px;
   }
 }


### PR DESCRIPTION
## Developer: Rucha Damle

Closes #195 

### Pull Request Summary
Updated the Add Event flow to validate required fields before moving to the next panel. Added the virtual meeting link input, back and close controls on each panel, error messages for missing required fields, and removed the long/lat display from the location step.

### Modifications

- `src/components/addEventPanel.tsx`
  - Added validation before moving to the next panel
  - Added error messages for missing title, date, time, and location
- `src/components/addEventLocationPanel.tsx`
  - Added virtual meeting link input
  - Added back button
  - Added close button
  - Removed long/lat display from the location step
  - Added location error messages
- `src/components/addEventMisc.tsx`
  - Added back button
  - Added close button
- `src/components/mapPin.tsx`
  - Removed long/lat display
- `src/styles/calendar.module.css`
  - Removed unnecessary `px` modifiers

### Testing Considerations

- Pressing Continue with missing required fields (title, start/end date and time, location/meeting link for virtual)
- Pressing Continue with invalid date/time (same start and end or end before start)
- Pressing Continue with all valid inputs
- Pressing Continue on location step w/ no location selected/no meeting link
- Navigating between panels using back button
- Pressing close icon from any panel
- Verifying correct error messages show for each case
- Verifying long/lat coordinates no longer appear

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
<img alt="image" src="https://github.com/user-attachments/assets/2effd740-651d-43b3-a7f4-7897ad0c36a0" width="50%"/>
<img alt="image" src="https://github.com/user-attachments/assets/c9838e4d-6cbf-4d78-9116-6221c8cf83bd" width="50%"/>
<img alt="image" src="https://github.com/user-attachments/assets/af2f9d35-ada1-4796-a063-4d1402942a34" width="50%"/>
<img alt="image" src="https://github.com/user-attachments/assets/b159dab5-6fbf-4182-a098-cac1c58e9b83" width="50%"/>
<img alt="image" src="https://github.com/user-attachments/assets/9c98e05b-d081-4ab5-af58-5af918d0dab1" width="50%"/>