### PR TITLE
feat: alert component optimization 197

### DIFF
--- a/src/admin_components/PendingApprovals.tsx
+++ b/src/admin_components/PendingApprovals.tsx
@@ -22,6 +22,11 @@ interface ApiResponse {
   data: Event[];
 }
 
+interface PendingApprovalsProps {
+  initialEvents?: Event[];
+  initialOrgs?: UserDocument[];
+}
+
 // Popup that asks for an optional reason when denying
 interface DenyPopupProps {
   isOpen: boolean;
@@ -64,14 +69,12 @@ function DenyPopup({ isOpen, onClose, onConfirm }: DenyPopupProps) {
   );
 }
 
-export default function PendingApprovals() {
-  const [pendingEvents, setPendingEvents] = useState<Event[]>([]);
-  const [pendingOrganizations, setPendingOrganizations] = useState<
-    UserDocument[]
-  >([]);
-  const [loadingEvents, setLoadingEvents] = useState(true);
+export default function PendingApprovals({ initialEvents, initialOrgs }: PendingApprovalsProps = {}) {
+  const [pendingEvents, setPendingEvents] = useState<Event[]>(initialEvents ?? []);
+  const [pendingOrganizations, setPendingOrganizations] = useState<UserDocument[]>(initialOrgs ?? []);
+  const [loadingEvents, setLoadingEvents] = useState(!initialEvents);
   const [errorEvents, setErrorEvents] = useState<string | null>(null);
-  const [loadingOrganizations, setLoadingOrganizations] = useState(true);
+  const [loadingOrganizations, setLoadingOrganizations] = useState(!initialOrgs);
   const [errorOrganizations, setErrorOrganizations] = useState<string | null>(
     null,
   );
@@ -83,6 +86,7 @@ export default function PendingApprovals() {
   const [selectedOrgId, setSelectedOrgId] = useState<string | null>(null);
 
   useEffect(() => {
+    if (initialEvents) return;
     const fetchPendingEvents = async () => {
       try {
         setLoadingEvents(true);
@@ -113,6 +117,7 @@ export default function PendingApprovals() {
   }, []); // Runs once on mount
 
   useEffect(() => {
+    if (initialOrgs) return;
     const fetchPendingOrganizations = async () => {
       try {
         setLoadingOrganizations(true);

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -14,6 +14,8 @@ const Navbar: React.FC = () => {
     const clerk = useClerk();
     const [isOpen, setIsOpen] = useState(false)
     const [hasPending, setHasPending] = useState(false);
+    const [pendingEvents, setPendingEvents] = useState<any[]>([]);
+    const [pendingOrgs, setPendingOrgs] = useState<any[]>([]);
     const { pathname } = router;
 
     const menuItems = [];
@@ -23,6 +25,7 @@ const Navbar: React.FC = () => {
 
     const DONT_SHOW_LOGIN_PATHS = ["/login", "/signup", "/forgot-password"];
     useEffect(() => {
+    if (role !== "admin") return;
     const checkPending = async () => {
         try {
             const eventsRes = await fetch("/api/users/eventRoutes");
@@ -33,22 +36,24 @@ const Navbar: React.FC = () => {
             const eventsData = await eventsRes.json();
             const orgsData = await orgsRes.json();
 
-            const pendingEvents = (eventsData?.data || []).filter(
+            const filteredEvents = (eventsData?.data || []).filter(
                 (e: any) => e.status === "Pending"
             );
 
-            const pendingOrgs = (orgsData?.data || []).filter(
+            const filteredOrgs = (orgsData?.data || []).filter(
                 (u: any) => u.role === "pending"
             );
 
-            setHasPending(pendingEvents.length > 0 || pendingOrgs.length > 0);
+            setPendingEvents(filteredEvents);
+            setPendingOrgs(filteredOrgs);
+            setHasPending(filteredEvents.length > 0 || filteredOrgs.length > 0);
         } catch (err) {
             console.error("Error checking pending approvals:", err);
         }
     };
 
     checkPending();
-}, []);
+}, [role]);
 
     var eventsPath: string;
     if (role === "admin") {
@@ -92,7 +97,7 @@ const Navbar: React.FC = () => {
             </Link>
             {clerk.user && (role === "approved" || role === "admin") && (
                 <div className={styles.dropdown}>
-                    <Alert onClick={() => setIsOpen(true)} hasPending={hasPending} />
+                    {role === "admin" && <Alert onClick={() => setIsOpen(true)} hasPending={hasPending} />}
                     <PositionedMenu items={menuItems} />
                 </div>
             )}{" "}
@@ -103,7 +108,7 @@ const Navbar: React.FC = () => {
                     <button className={styles.modalClose} onClick={() => setIsOpen(false)} type = "button">
                         x
                     </button>
-                    <PendingApprovals />
+                    <PendingApprovals initialEvents={pendingEvents} initialOrgs={pendingOrgs} />
                 </div>
                 </>
             )}


### PR DESCRIPTION
## Developer: Sean McCormick

Closes #197

### Pull Request Summary

Optimizes the Alert/PendingApprovals flow by eliminating duplicate database fetches and restricting the Alert bell icon to admin users only. The Navbar now fetches events and orgs once and passes the data directly into PendingApprovals, so opening the modal does not trigger a second fetch.

### Modifications

- src/components/navbar.tsx: Restricted Alert bell icon to admin role only; stored fetched events/orgs in state and passed them as props to PendingApprovals
- src/admin_components/PendingApprovals.tsx: Added optional initialEvents and initialOrgs props; skips internal fetches when initial data is provided

### Testing Considerations

- Log in as admin: bell icon and hamburger menu both visible 
- As admin, open the Pending Approvals modal: no new eventRoutes or userRoutes network calls fire 
- Navigate to /adminDashboard: PendingApprovals still renders correctly with its own fetch 
- Log in as approved user: hamburger menu visible, no bell icon  
- could not verify locally due to incorrect MONGO_URI and Clerk keys in local .env (please verify in a fully configured environment)

Note for reviewer: /adminDashboard still triggers a duplicate fetch (Navbar + PendingApprovals fetch independently) since there is no shared data layer between them. This would require lifting state up through Layout or adding a React context — left for a follow-up issue.

**Note for reviewer:** /adminDashboard still triggers a duplicate fetch (Navbar + PendingApprovals fetch independently) since there is no shared data layer between them. This would require lifting state up through Layout or adding a React context so left for a follow-up issue.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="202" height="62" alt="image" src="https://github.com/user-attachments/assets/eefe5f92-d8cd-4a84-bb0b-a1e301552a43" />
<img width="555" height="221" alt="image" src="https://github.com/user-attachments/assets/db5ac4ce-5966-4f7d-8b5f-2f3f7b5ebe3d" />