### PR TITLE
fix: wire image upload to S3 and secure AWS credentials

### DIFF
--- a/src/components/addEventMisc.tsx
+++ b/src/components/addEventMisc.tsx
@@ -9,12 +9,14 @@ type AddEventMiscProps = {
   onBack: () => void;
   onClose: () => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onPhotoChange: (photo: File | null) => void;
 };
 
 export default function AddEventMisc({
   onBack,
   onClose,
   onSubmit,
+  onPhotoChange,
 }: AddEventMiscProps) {
   const [details, setDetails] = useState("");
   const [photo, setPhoto] = useState<File | null>(null);
@@ -27,6 +29,7 @@ export default function AddEventMisc({
     onDrop: (acceptedFiles: File[]) => {
       const file = acceptedFiles[0] ?? null;
       setPhoto(file);
+      onPhotoChange(file);
       if (file) setImagePreviewUrl(URL.createObjectURL(file));
     },
   });

--- a/src/components/addEventPanel.tsx
+++ b/src/components/addEventPanel.tsx
@@ -579,6 +579,7 @@ export default function AddEventPanel({
           onBack={() => handleBack("location")}
           onClose={onClose}
           onSubmit={onEventAdd}
+          onPhotoChange={(photo) => setFormData((prev) => ({ ...prev, photo }))}
         />
       )}
     </>

--- a/src/pages/api/s3-upload/route.tsx
+++ b/src/pages/api/s3-upload/route.tsx
@@ -10,9 +10,9 @@ import fs from "fs";
 import sharp from "sharp";
 import getRawBody from "raw-body";
 
-const region = process.env.NEXT_PUBLIC_AWS_REGION;
-const accessKeyId = process.env.NEXT_PUBLIC_AWS_ACCESS_KEY_ID;
-const secretAccessKey = process.env.NEXT_PUBLIC_AWS_SECRET_ACCESS_KEY;
+const region = process.env.AWS_REGION;
+const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 
 if (!region || !accessKeyId || !secretAccessKey) {
   throw new Error("AWS environment variables are missing");
@@ -120,18 +120,18 @@ async function handleDelete(req: NextApiRequest, res: NextApiResponse) {
 
 async function uploadFileToS3(file: any, fileName: string) {
   const params = {
-    Bucket: process.env.NEXT_PUBLIC_S3_BUCKET_NAME!,
+    Bucket: process.env.S3_BUCKET_NAME!,
     Key: `${Date.now()}-${fileName}`,
     Body: file,
     ContentType: "image/jpeg",
   };
   await s3Client.send(new PutObjectCommand(params));
-  return `https://${params.Bucket}.s3.amazonaws.com/${params.Key}`;
+  return `https://${params.Bucket}.s3.${region}.amazonaws.com/${params.Key}`;
 }
 
 function getKeyFromUrl(url: string): string {
-  const bucketName = process.env.NEXT_PUBLIC_S3_BUCKET_NAME!;
-  const bucketUrl = `https://${bucketName}.s3.amazonaws.com/`;
+  const bucketName = process.env.S3_BUCKET_NAME!;
+  const bucketUrl = `https://${bucketName}.s3.${region}.amazonaws.com/`;
 
   if (!url.startsWith(bucketUrl)) {
     console.log("KEY ERROR");
@@ -145,7 +145,7 @@ function getKeyFromUrl(url: string): string {
 
 async function deleteFileFromS3(key: string) {
   const params = {
-    Bucket: process.env.NEXT_PUBLIC_S3_BUCKET_NAME!,
+    Bucket: process.env.S3_BUCKET_NAME!,
     Key: key,
   };
   await s3Client.send(new DeleteObjectCommand(params));


### PR DESCRIPTION
- Pass photo from AddEventMisc to parent via onPhotoChange callback so uploads actually fire                      
  - Remove NEXT_PUBLIC_ prefix from AWS env vars to keep credentials server-side only
  - Include region in S3 URL and getKeyFromUrl to support non-us-east-1 buckets                                     
                            
  ## Developer: Jeron Tre Perey                                                                                     
                            
  Closes #202                                                                                                       
                            
  ### Pull Request Summary

  Fixes the image upload flow so that photos selected in the event form are actually sent to S3 on submission.      
  Previously, the selected file was stored in local state inside `AddEventMisc` but never passed up to the parent,
  so the upload call was always skipped. This PR also moves AWS credentials server-side (removes `NEXT_PUBLIC_`     
  prefix) to prevent secret exposure in the client bundle, and includes the bucket region in the S3 URL and key
  parser to support non-us-east-1 deployments.

  ### Modifications

  - `src/components/addEventMisc.tsx` — Added `onPhotoChange` callback prop; calls it whenever a file is            
  dropped/selected so the parent receives the file
  - `src/components/addEventPanel.tsx` — Passes `onPhotoChange` handler to `AddEventMisc` that writes the selected  
  file into `formData.photo`, wiring it into the existing upload logic                                              
  - `src/pages/api/s3-upload/route.tsx` — Removed `NEXT_PUBLIC_` prefix from AWS env var references; added region to
   the constructed S3 URL and to `getKeyFromUrl` so bucket region is correctly handled                              
                            
  ### Testing Considerations                                                                                        
                            
  - Create a new event and attach an image — verify the image appears correctly on the event after submission       
  - Create an event without an image — verify submission still succeeds with no upload attempted
  - Confirm AWS env vars no longer have `NEXT_PUBLIC_` prefix in `.env.local` and that the upload route still       
  authenticates successfully                                                                                        
  - Verify the returned S3 URL includes the correct region segment                                                  
  - Reviewer should confirm no AWS credentials are exposed in client-side bundle (check network tab / built JS)     
                                                                                                                    
  ### Pull Request Checklist                                                                                        
  - [ x] Code is neat, readable, and works                                                                           
  - [x ] Comments are appropriate                                                                                    
  - [x ] The commit messages follows our
  [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)                       
  - [ x] The developer name is specified                                                      
  - [ x] The summary is completed       
  - [x ] Assign reviewers                                                                                            
                        
  ### Screenshots/Screencast                                                                                        
                            
  {put screenshots of your change, or even better a screencast displaying the functionality}
                                                                                            