### PR TITLE
212 calendar filter

### DIFF
--- a/src/components/calendarFilterModal.tsx
+++ b/src/components/calendarFilterModal.tsx
@@ -23,6 +23,10 @@ export default function CalendarFilterModal({
   onClose,
 }: CalendarFilterModalProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const [draftHiddenOrganizations, setDraftHiddenOrganizations] =
+    useState(hiddenOrganizations);
+  const [draftShowVirtual, setDraftShowVirtual] = useState(showVirtual);
+  const [draftShowInPerson, setDraftShowInPerson] = useState(showInPerson);
   const organizations = useMemo(() => {
     return Array.from(
       new Set(events.map((event) => event.organization).filter(Boolean)),
@@ -34,22 +38,29 @@ export default function CalendarFilterModal({
   }, []);
 
   const isOrganizationShown = (organization: string) =>
-    !hiddenOrganizations.includes(organization);
+    !draftHiddenOrganizations.includes(organization);
 
   const handleOrganizationChange = (organization: string, checked: boolean) => {
     if (checked) {
-      onHiddenOrganizationsChange(
-        hiddenOrganizations.filter((name) => name !== organization),
+      setDraftHiddenOrganizations(
+        draftHiddenOrganizations.filter((name) => name !== organization),
       );
       return;
     }
 
-    onHiddenOrganizationsChange([...hiddenOrganizations, organization]);
+    setDraftHiddenOrganizations([...draftHiddenOrganizations, organization]);
   };
 
   const handleClose = () => {
     setIsVisible(false);
     setTimeout(onClose, 150);
+  };
+
+  const handleApply = () => {
+    onHiddenOrganizationsChange(draftHiddenOrganizations);
+    onShowVirtualChange(draftShowVirtual);
+    onShowInPersonChange(draftShowInPerson);
+    handleClose();
   };
 
   return (
@@ -110,33 +121,33 @@ export default function CalendarFilterModal({
           <div style={styles.options}>
             <button
               type="button"
-              aria-pressed={showVirtual}
+              aria-pressed={draftShowVirtual}
               style={{
                 ...styles.filterButton,
-                ...(showVirtual
+                ...(draftShowVirtual
                   ? styles.filterButtonActive
                   : styles.filterButtonInactive),
               }}
-              onClick={() => onShowVirtualChange(!showVirtual)}
+              onClick={() => setDraftShowVirtual(!draftShowVirtual)}
             >
               Virtual
             </button>
             <button
               type="button"
-              aria-pressed={showInPerson}
+              aria-pressed={draftShowInPerson}
               style={{
                 ...styles.filterButton,
-                ...(showInPerson
+                ...(draftShowInPerson
                   ? styles.filterButtonActive
                   : styles.filterButtonInactive),
               }}
-              onClick={() => onShowInPersonChange(!showInPerson)}
+              onClick={() => setDraftShowInPerson(!draftShowInPerson)}
             >
               In Person
             </button>
           </div>
         </div>
-        <button style={styles.applyButton} onClick={handleClose} type="button">
+        <button style={styles.applyButton} onClick={handleApply} type="button">
           Apply
         </button>
       </div>

--- a/src/components/calendarFilterModal.tsx
+++ b/src/components/calendarFilterModal.tsx
@@ -3,11 +3,23 @@ import { EventDocument } from "../database/eventSchema";
 
 type CalendarFilterModalProps = {
   events: EventDocument[];
+  hiddenOrganizations: string[];
+  onHiddenOrganizationsChange: (organizations: string[]) => void;
+  showVirtual: boolean;
+  onShowVirtualChange: (showVirtual: boolean) => void;
+  showInPerson: boolean;
+  onShowInPersonChange: (showInPerson: boolean) => void;
   onClose: () => void;
 };
 
 export default function CalendarFilterModal({
   events,
+  hiddenOrganizations,
+  onHiddenOrganizationsChange,
+  showVirtual,
+  onShowVirtualChange,
+  showInPerson,
+  onShowInPersonChange,
   onClose,
 }: CalendarFilterModalProps) {
   const organizations = useMemo(() => {
@@ -15,6 +27,17 @@ export default function CalendarFilterModal({
       new Set(events.map((event) => event.organization).filter(Boolean)),
     ).sort();
   }, [events]);
+
+  const handleOrganizationChange = (organization: string, checked: boolean) => {
+    if (checked) {
+      onHiddenOrganizationsChange(
+        hiddenOrganizations.filter((name) => name !== organization),
+      );
+      return;
+    }
+
+    onHiddenOrganizationsChange([...hiddenOrganizations, organization]);
+  };
 
   return (
     <>
@@ -30,7 +53,16 @@ export default function CalendarFilterModal({
             {organizations.length > 0 ? (
               organizations.map((organization) => (
                 <label key={organization} style={styles.option}>
-                  <input type="checkbox" defaultChecked />
+                  <input
+                    type="checkbox"
+                    checked={!hiddenOrganizations.includes(organization)}
+                    onChange={(event) =>
+                      handleOrganizationChange(
+                        organization,
+                        event.target.checked,
+                      )
+                    }
+                  />
                   {organization}
                 </label>
               ))
@@ -43,11 +75,19 @@ export default function CalendarFilterModal({
           <h3 style={styles.sectionTitle}>Location</h3>
           <div style={styles.options}>
             <label style={styles.option}>
-              <input type="checkbox" defaultChecked />
+              <input
+                type="checkbox"
+                checked={showVirtual}
+                onChange={(event) => onShowVirtualChange(event.target.checked)}
+              />
               Virtual
             </label>
             <label style={styles.option}>
-              <input type="checkbox" defaultChecked />
+              <input
+                type="checkbox"
+                checked={showInPerson}
+                onChange={(event) => onShowInPersonChange(event.target.checked)}
+              />
               In Person
             </label>
           </div>

--- a/src/components/calendarFilterModal.tsx
+++ b/src/components/calendarFilterModal.tsx
@@ -192,7 +192,7 @@ const styles: { [key: string]: React.CSSProperties } = {
   },
   title: {
     margin: "0 0 20px",
-    color: "#335543",
+    color: "#000000",
     fontSize: "1.4rem",
     fontWeight: 700,
     fontFamily: '"DM Sans", sans-serif',
@@ -204,7 +204,7 @@ const styles: { [key: string]: React.CSSProperties } = {
     margin: "0 0 12px",
     fontSize: "1rem",
     fontWeight: 700,
-    color: "#335543",
+    color: "#000000",
     fontFamily: '"DM Sans", sans-serif',
   },
   options: {
@@ -221,11 +221,12 @@ const styles: { [key: string]: React.CSSProperties } = {
     fontWeight: 400,
     lineHeight: 1,
     cursor: "pointer",
-    transition: "background-color 150ms ease, border-color 150ms ease, color 150ms ease",
+    transition:
+      "background-color 150ms ease, border-color 150ms ease, color 150ms ease",
   },
   filterButtonActive: {
-    backgroundColor: "#6d6d6d",
-    borderColor: "#6d6d6d",
+    backgroundColor: "#335543",
+    borderColor: "#335543",
     color: "white",
   },
   filterButtonInactive: {

--- a/src/components/calendarFilterModal.tsx
+++ b/src/components/calendarFilterModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { EventDocument } from "../database/eventSchema";
 
 type CalendarFilterModalProps = {
@@ -22,11 +22,19 @@ export default function CalendarFilterModal({
   onShowInPersonChange,
   onClose,
 }: CalendarFilterModalProps) {
+  const [isVisible, setIsVisible] = useState(false);
   const organizations = useMemo(() => {
     return Array.from(
       new Set(events.map((event) => event.organization).filter(Boolean)),
     ).sort();
   }, [events]);
+
+  useEffect(() => {
+    requestAnimationFrame(() => setIsVisible(true));
+  }, []);
+
+  const isOrganizationShown = (organization: string) =>
+    !hiddenOrganizations.includes(organization);
 
   const handleOrganizationChange = (organization: string, checked: boolean) => {
     if (checked) {
@@ -39,11 +47,30 @@ export default function CalendarFilterModal({
     onHiddenOrganizationsChange([...hiddenOrganizations, organization]);
   };
 
+  const handleClose = () => {
+    setIsVisible(false);
+    setTimeout(onClose, 150);
+  };
+
   return (
     <>
-      <div style={styles.overlay} onClick={onClose} />
-      <div style={styles.modal}>
-        <button style={styles.closeButton} onClick={onClose} type="button">
+      <div
+        style={{
+          ...styles.overlay,
+          opacity: isVisible ? 1 : 0,
+        }}
+        onClick={handleClose}
+      />
+      <div
+        style={{
+          ...styles.modal,
+          opacity: isVisible ? 1 : 0,
+          transform: isVisible
+            ? "translate(-50%, -50%) scale(1)"
+            : "translate(-50%, -48%) scale(0.98)",
+        }}
+      >
+        <button style={styles.closeButton} onClick={handleClose} type="button">
           x
         </button>
         <h2 style={styles.title}>Filter Events</h2>
@@ -52,47 +79,64 @@ export default function CalendarFilterModal({
           <div style={styles.options}>
             {organizations.length > 0 ? (
               organizations.map((organization) => (
-                <label key={organization} style={styles.option}>
-                  <input
-                    type="checkbox"
-                    checked={!hiddenOrganizations.includes(organization)}
-                    onChange={(event) =>
-                      handleOrganizationChange(
-                        organization,
-                        event.target.checked,
-                      )
-                    }
-                  />
+                <button
+                  key={organization}
+                  type="button"
+                  aria-pressed={isOrganizationShown(organization)}
+                  style={{
+                    ...styles.filterButton,
+                    ...(isOrganizationShown(organization)
+                      ? styles.filterButtonActive
+                      : styles.filterButtonInactive),
+                  }}
+                  onClick={() =>
+                    handleOrganizationChange(
+                      organization,
+                      !isOrganizationShown(organization),
+                    )
+                  }
+                >
                   {organization}
-                </label>
+                </button>
               ))
             ) : (
               <p style={styles.emptyText}>No organizations available.</p>
             )}
           </div>
         </div>
+        <div style={styles.divider} />
         <div style={styles.section}>
           <h3 style={styles.sectionTitle}>Location</h3>
           <div style={styles.options}>
-            <label style={styles.option}>
-              <input
-                type="checkbox"
-                checked={showVirtual}
-                onChange={(event) => onShowVirtualChange(event.target.checked)}
-              />
+            <button
+              type="button"
+              aria-pressed={showVirtual}
+              style={{
+                ...styles.filterButton,
+                ...(showVirtual
+                  ? styles.filterButtonActive
+                  : styles.filterButtonInactive),
+              }}
+              onClick={() => onShowVirtualChange(!showVirtual)}
+            >
               Virtual
-            </label>
-            <label style={styles.option}>
-              <input
-                type="checkbox"
-                checked={showInPerson}
-                onChange={(event) => onShowInPersonChange(event.target.checked)}
-              />
+            </button>
+            <button
+              type="button"
+              aria-pressed={showInPerson}
+              style={{
+                ...styles.filterButton,
+                ...(showInPerson
+                  ? styles.filterButtonActive
+                  : styles.filterButtonInactive),
+              }}
+              onClick={() => onShowInPersonChange(!showInPerson)}
+            >
               In Person
-            </label>
+            </button>
           </div>
         </div>
-        <button style={styles.applyButton} onClick={onClose} type="button">
+        <button style={styles.applyButton} onClick={handleClose} type="button">
           Apply
         </button>
       </div>
@@ -106,22 +150,24 @@ const styles: { [key: string]: React.CSSProperties } = {
     inset: 0,
     background: "rgba(0, 0, 0, 0.6)",
     zIndex: 999,
+    transition: "opacity 150ms ease",
   },
   modal: {
     position: "fixed",
     top: "50%",
     left: "50%",
-    transform: "translate(-50%, -50%)",
-    width: "420px",
+    width: "380px",
     maxWidth: "90vw",
-    maxHeight: "85vh",
+    maxHeight: "75vh",
     overflowY: "auto",
     background: "white",
-    borderRadius: "12px",
-    padding: "24px",
+    borderRadius: "16px",
+    padding: "24px 22px",
     zIndex: 1000,
     boxShadow: "0px 0px 10px rgba(0, 0, 0, 0.1)",
     whiteSpace: "normal",
+    fontFamily: '"DM Sans", sans-serif',
+    transition: "opacity 150ms ease, transform 150ms ease",
   },
   closeButton: {
     position: "absolute",
@@ -130,11 +176,15 @@ const styles: { [key: string]: React.CSSProperties } = {
     background: "transparent",
     border: "none",
     fontSize: "20px",
+    fontFamily: '"DM Sans", sans-serif',
     cursor: "pointer",
   },
   title: {
     margin: "0 0 20px",
-    fontSize: "1.5rem",
+    color: "#335543",
+    fontSize: "1.4rem",
+    fontWeight: 700,
+    fontFamily: '"DM Sans", sans-serif',
   },
   section: {
     marginBottom: "20px",
@@ -142,21 +192,44 @@ const styles: { [key: string]: React.CSSProperties } = {
   sectionTitle: {
     margin: "0 0 12px",
     fontSize: "1rem",
+    fontWeight: 700,
+    color: "#335543",
+    fontFamily: '"DM Sans", sans-serif',
   },
   options: {
     display: "flex",
-    flexDirection: "column",
-    gap: "10px",
-  },
-  option: {
-    display: "flex",
-    alignItems: "center",
+    flexWrap: "wrap",
     gap: "8px",
+  },
+  filterButton: {
+    borderRadius: "9999px",
+    border: "1px solid #989898",
+    padding: "8px 14px",
+    fontFamily: '"DM Sans", sans-serif',
     fontSize: "0.95rem",
+    fontWeight: 400,
+    lineHeight: 1,
+    cursor: "pointer",
+    transition: "background-color 150ms ease, border-color 150ms ease, color 150ms ease",
+  },
+  filterButtonActive: {
+    backgroundColor: "#6d6d6d",
+    borderColor: "#6d6d6d",
+    color: "white",
+  },
+  filterButtonInactive: {
+    backgroundColor: "#f0f0f0",
+    borderColor: "#989898",
+    color: "#333",
+  },
+  divider: {
+    borderTop: "1px solid #D1D5DC",
+    margin: "4px 0 20px",
   },
   emptyText: {
     margin: 0,
     color: "#666",
+    fontFamily: '"DM Sans", sans-serif',
   },
   applyButton: {
     backgroundColor: "#F7AB74",
@@ -164,6 +237,11 @@ const styles: { [key: string]: React.CSSProperties } = {
     border: "none",
     padding: "10px 20px",
     borderRadius: "20px",
+    fontFamily: '"DM Sans", sans-serif',
+    fontSize: "0.95rem",
+    fontWeight: 400,
+    lineHeight: 1,
     cursor: "pointer",
+    transition: "background-color 150ms ease, opacity 150ms ease",
   },
 };

--- a/src/components/calendarFilterModal.tsx
+++ b/src/components/calendarFilterModal.tsx
@@ -1,0 +1,129 @@
+import React, { useMemo } from "react";
+import { EventDocument } from "../database/eventSchema";
+
+type CalendarFilterModalProps = {
+  events: EventDocument[];
+  onClose: () => void;
+};
+
+export default function CalendarFilterModal({
+  events,
+  onClose,
+}: CalendarFilterModalProps) {
+  const organizations = useMemo(() => {
+    return Array.from(
+      new Set(events.map((event) => event.organization).filter(Boolean)),
+    ).sort();
+  }, [events]);
+
+  return (
+    <>
+      <div style={styles.overlay} onClick={onClose} />
+      <div style={styles.modal}>
+        <button style={styles.closeButton} onClick={onClose} type="button">
+          x
+        </button>
+        <h2 style={styles.title}>Filter Events</h2>
+        <div style={styles.section}>
+          <h3 style={styles.sectionTitle}>Organizations</h3>
+          <div style={styles.options}>
+            {organizations.length > 0 ? (
+              organizations.map((organization) => (
+                <label key={organization} style={styles.option}>
+                  <input type="checkbox" defaultChecked />
+                  {organization}
+                </label>
+              ))
+            ) : (
+              <p style={styles.emptyText}>No organizations available.</p>
+            )}
+          </div>
+        </div>
+        <div style={styles.section}>
+          <h3 style={styles.sectionTitle}>Location</h3>
+          <div style={styles.options}>
+            <label style={styles.option}>
+              <input type="checkbox" defaultChecked />
+              Virtual
+            </label>
+            <label style={styles.option}>
+              <input type="checkbox" defaultChecked />
+              In Person
+            </label>
+          </div>
+        </div>
+        <button style={styles.applyButton} onClick={onClose} type="button">
+          Apply
+        </button>
+      </div>
+    </>
+  );
+}
+
+const styles: { [key: string]: React.CSSProperties } = {
+  overlay: {
+    position: "fixed",
+    inset: 0,
+    background: "rgba(0, 0, 0, 0.6)",
+    zIndex: 999,
+  },
+  modal: {
+    position: "fixed",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    width: "420px",
+    maxWidth: "90vw",
+    maxHeight: "85vh",
+    overflowY: "auto",
+    background: "white",
+    borderRadius: "12px",
+    padding: "24px",
+    zIndex: 1000,
+    boxShadow: "0px 0px 10px rgba(0, 0, 0, 0.1)",
+    whiteSpace: "normal",
+  },
+  closeButton: {
+    position: "absolute",
+    top: "12px",
+    right: "16px",
+    background: "transparent",
+    border: "none",
+    fontSize: "20px",
+    cursor: "pointer",
+  },
+  title: {
+    margin: "0 0 20px",
+    fontSize: "1.5rem",
+  },
+  section: {
+    marginBottom: "20px",
+  },
+  sectionTitle: {
+    margin: "0 0 12px",
+    fontSize: "1rem",
+  },
+  options: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "10px",
+  },
+  option: {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+    fontSize: "0.95rem",
+  },
+  emptyText: {
+    margin: 0,
+    color: "#666",
+  },
+  applyButton: {
+    backgroundColor: "#F7AB74",
+    color: "black",
+    border: "none",
+    padding: "10px 20px",
+    borderRadius: "20px",
+    cursor: "pointer",
+  },
+};

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -16,7 +16,7 @@ import style1 from "../styles/calendar.module.css";
 import { useClerk } from "@clerk/clerk-react";
 import { EventDocument } from "../database/eventSchema";
 import { useRouter } from "next/router";
-import { convertEventDatesToDates } from "../utils/events";
+import { convertEventDatesToDates, filterEvents } from "../utils/events";
 import { DateTime } from "luxon";
 import { useUser } from "@clerk/clerk-react";
 import AddEventLocationPanel from "../components/addEventLocationPanel";
@@ -77,32 +77,13 @@ export default function CalendarPage() {
   const [toolbarSearchStyle, setToolbarSearchStyle] =
     useState<React.CSSProperties>({ display: "none" });
   const filteredEvents = useMemo(() => {
-    const normalizedSearchTerm = searchTerm.trim().toLowerCase();
-
-    return events.filter((event) => {
-      const passesOrganization = !hiddenOrganizations.includes(
-        event.organization,
-      );
-      const passesLocation = event.isVirtual ? showVirtual : showInPerson;
-
-      if (!passesOrganization || !passesLocation) {
-        return false;
-      }
-
-      if (!normalizedSearchTerm) {
-        return true;
-      }
-
-      const title = event.title?.toLowerCase() ?? "";
-      const description = event.description?.toLowerCase() ?? "";
-      const organization = event.organization?.toLowerCase() ?? "";
-
-      return (
-        title.includes(normalizedSearchTerm) ||
-        description.includes(normalizedSearchTerm) ||
-        organization.includes(normalizedSearchTerm)
-      );
-    });
+    return filterEvents(
+      events,
+      searchTerm,
+      hiddenOrganizations,
+      showVirtual,
+      showInPerson,
+    );
   }, [events, hiddenOrganizations, searchTerm, showInPerson, showVirtual]);
   const visibleMonthEvents = useMemo(() => {
     if (!visibleDateRange) {

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import useSWR, { mutate } from "swr";
 import AddEventPanel from "../components/addEventPanel";
 import EventRequestPopup from "../components/eventRequestPopup";
+import CalendarFilterModal from "../components/calendarFilterModal";
 import style1 from "../styles/calendar.module.css";
 import { useClerk } from "@clerk/clerk-react";
 import { EventDocument } from "../database/eventSchema";
@@ -58,6 +59,7 @@ export default function CalendarPage() {
   );
   const [resize, setResize] = useState(false);
   const [isAddingEvent, setIsAddingEvent] = useState(false);
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isShowingEventPopUp, setIsShowingEventPopUp] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [toolbarSearchTerm, setToolbarSearchTerm] = useState("");
@@ -135,7 +137,9 @@ export default function CalendarPage() {
       },
       filterButton: {
         text: "Filter",
-        click: () => {}, // no-op
+        click: () => {
+          setIsFilterOpen(true);
+        },
       },
     }),
     [],
@@ -325,6 +329,12 @@ export default function CalendarPage() {
     <Layout>
       {isShowingEventPopUp && user?.publicMetadata?.role != "admin" && (
         <EventRequestPopup onClose={() => setIsShowingEventPopUp(false)} />
+      )}
+      {isFilterOpen && (
+        <CalendarFilterModal
+          events={events}
+          onClose={() => setIsFilterOpen(false)}
+        />
       )}
       <div className={style1.calendarPageContainer} ref={calendarRef}>
           <style>{calendarStyles}</style>

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -61,6 +61,9 @@ export default function CalendarPage() {
   const [isAddingEvent, setIsAddingEvent] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isShowingEventPopUp, setIsShowingEventPopUp] = useState(false);
+  const [hiddenOrganizations, setHiddenOrganizations] = useState<string[]>([]);
+  const [showVirtual, setShowVirtual] = useState(true);
+  const [showInPerson, setShowInPerson] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
   const [toolbarSearchTerm, setToolbarSearchTerm] = useState("");
   const [visibleDateRange, setVisibleDateRange] =
@@ -76,11 +79,20 @@ export default function CalendarPage() {
   const filteredEvents = useMemo(() => {
     const normalizedSearchTerm = searchTerm.trim().toLowerCase();
 
-    if (!normalizedSearchTerm) {
-      return events;
-    }
-
     return events.filter((event) => {
+      const passesOrganization = !hiddenOrganizations.includes(
+        event.organization,
+      );
+      const passesLocation = event.isVirtual ? showVirtual : showInPerson;
+
+      if (!passesOrganization || !passesLocation) {
+        return false;
+      }
+
+      if (!normalizedSearchTerm) {
+        return true;
+      }
+
       const title = event.title?.toLowerCase() ?? "";
       const description = event.description?.toLowerCase() ?? "";
       const organization = event.organization?.toLowerCase() ?? "";
@@ -91,7 +103,7 @@ export default function CalendarPage() {
         organization.includes(normalizedSearchTerm)
       );
     });
-  }, [events, searchTerm]);
+  }, [events, hiddenOrganizations, searchTerm, showInPerson, showVirtual]);
   const visibleMonthEvents = useMemo(() => {
     if (!visibleDateRange) {
       return filteredEvents;
@@ -333,6 +345,12 @@ export default function CalendarPage() {
       {isFilterOpen && (
         <CalendarFilterModal
           events={events}
+          hiddenOrganizations={hiddenOrganizations}
+          onHiddenOrganizationsChange={setHiddenOrganizations}
+          showVirtual={showVirtual}
+          onShowVirtualChange={setShowVirtual}
+          showInPerson={showInPerson}
+          onShowInPersonChange={setShowInPerson}
           onClose={() => setIsFilterOpen(false)}
         />
       )}

--- a/src/pages/publicCalendar.tsx
+++ b/src/pages/publicCalendar.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import AddEventPanel from "../components/addEventPanel";
 import Link from "next/link";
 import EventRequestPopup from "../components/eventRequestPopup";
+import CalendarFilterModal from "../components/calendarFilterModal";
 import style1 from "../styles/calendar.module.css";
 import { useClerk } from "@clerk/clerk-react";
 import { EventDocument } from "../database/eventSchema";
@@ -49,6 +50,7 @@ export default function CalendarPage() {
   );
   const [resize, setResize] = useState(false);
   const [isAddingEvent, setIsAddingEvent] = useState(false);
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isShowingEventPopUp, setIsShowingEventPopUp] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [toolbarSearchTerm, setToolbarSearchTerm] = useState("");
@@ -134,7 +136,9 @@ export default function CalendarPage() {
       },
       filterButton: {
         text: "Filter",
-        click: () => {}, // no-op
+        click: () => {
+          setIsFilterOpen(true);
+        },
       },
     }),
     [],
@@ -335,6 +339,12 @@ export default function CalendarPage() {
     <Layout>
       {isShowingEventPopUp && user?.publicMetadata?.role != "admin" && (
         <EventRequestPopup onClose={() => setIsShowingEventPopUp(false)} />
+      )}
+      {isFilterOpen && (
+        <CalendarFilterModal
+          events={events}
+          onClose={() => setIsFilterOpen(false)}
+        />
       )}
       <div className={style1.calendarPageContainer} ref={calendarRef}>
           <style>{calendarStyles}</style>

--- a/src/pages/publicCalendar.tsx
+++ b/src/pages/publicCalendar.tsx
@@ -52,6 +52,9 @@ export default function CalendarPage() {
   const [isAddingEvent, setIsAddingEvent] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isShowingEventPopUp, setIsShowingEventPopUp] = useState(false);
+  const [hiddenOrganizations, setHiddenOrganizations] = useState<string[]>([]);
+  const [showVirtual, setShowVirtual] = useState(true);
+  const [showInPerson, setShowInPerson] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
   const [toolbarSearchTerm, setToolbarSearchTerm] = useState("");
   const [visibleDateRange, setVisibleDateRange] =
@@ -68,11 +71,20 @@ export default function CalendarPage() {
   const filteredEvents = useMemo(() => {
     const normalizedSearchTerm = searchTerm.trim().toLowerCase();
 
-    if (!normalizedSearchTerm) {
-      return events;
-    }
-
     return events.filter((event) => {
+      const passesOrganization = !hiddenOrganizations.includes(
+        event.organization,
+      );
+      const passesLocation = event.isVirtual ? showVirtual : showInPerson;
+
+      if (!passesOrganization || !passesLocation) {
+        return false;
+      }
+
+      if (!normalizedSearchTerm) {
+        return true;
+      }
+
       const title = event.title?.toLowerCase() ?? "";
       const description = event.description?.toLowerCase() ?? "";
       const organization = event.organization?.toLowerCase() ?? "";
@@ -83,7 +95,7 @@ export default function CalendarPage() {
         organization.includes(normalizedSearchTerm)
       );
     });
-  }, [events, searchTerm]);
+  }, [events, hiddenOrganizations, searchTerm, showInPerson, showVirtual]);
   const visibleMonthEvents = useMemo(() => {
     if (!visibleDateRange) {
       return filteredEvents;
@@ -343,6 +355,12 @@ export default function CalendarPage() {
       {isFilterOpen && (
         <CalendarFilterModal
           events={events}
+          hiddenOrganizations={hiddenOrganizations}
+          onHiddenOrganizationsChange={setHiddenOrganizations}
+          showVirtual={showVirtual}
+          onShowVirtualChange={setShowVirtual}
+          showInPerson={showInPerson}
+          onShowInPersonChange={setShowInPerson}
           onClose={() => setIsFilterOpen(false)}
         />
       )}

--- a/src/pages/publicCalendar.tsx
+++ b/src/pages/publicCalendar.tsx
@@ -16,7 +16,7 @@ import style1 from "../styles/calendar.module.css";
 import { useClerk } from "@clerk/clerk-react";
 import { EventDocument } from "../database/eventSchema";
 import { useRouter } from "next/router";
-import { convertEventDatesToDates } from "../utils/events";
+import { convertEventDatesToDates, filterEvents } from "../utils/events";
 import { DateTime } from "luxon";
 import { useSession } from "@clerk/nextjs";
 import { useUser } from "@clerk/clerk-react";
@@ -69,32 +69,13 @@ export default function CalendarPage() {
   const [toolbarSearchStyle, setToolbarSearchStyle] =
     useState<React.CSSProperties>({ display: "none" });
   const filteredEvents = useMemo(() => {
-    const normalizedSearchTerm = searchTerm.trim().toLowerCase();
-
-    return events.filter((event) => {
-      const passesOrganization = !hiddenOrganizations.includes(
-        event.organization,
-      );
-      const passesLocation = event.isVirtual ? showVirtual : showInPerson;
-
-      if (!passesOrganization || !passesLocation) {
-        return false;
-      }
-
-      if (!normalizedSearchTerm) {
-        return true;
-      }
-
-      const title = event.title?.toLowerCase() ?? "";
-      const description = event.description?.toLowerCase() ?? "";
-      const organization = event.organization?.toLowerCase() ?? "";
-
-      return (
-        title.includes(normalizedSearchTerm) ||
-        description.includes(normalizedSearchTerm) ||
-        organization.includes(normalizedSearchTerm)
-      );
-    });
+    return filterEvents(
+      events,
+      searchTerm,
+      hiddenOrganizations,
+      showVirtual,
+      showInPerson,
+    );
   }, [events, hiddenOrganizations, searchTerm, showInPerson, showVirtual]);
   const visibleMonthEvents = useMemo(() => {
     if (!visibleDateRange) {

--- a/src/utils/events.tsx
+++ b/src/utils/events.tsx
@@ -17,6 +17,41 @@ export function convertEventDatesToDates(events: EventDocument[]): void {
   });
 }
 
+export function filterEvents(
+  events: EventDocument[],
+  searchTerm: string,
+  hiddenOrganizations: string[],
+  showVirtual: boolean,
+  showInPerson: boolean,
+): EventDocument[] {
+  const normalizedSearchTerm = searchTerm.trim().toLowerCase();
+
+  return events.filter((event) => {
+    const passesOrganization = !hiddenOrganizations.includes(
+      event.organization,
+    );
+    const passesLocation = event.isVirtual ? showVirtual : showInPerson;
+
+    if (!passesOrganization || !passesLocation) {
+      return false;
+    }
+
+    if (!normalizedSearchTerm) {
+      return true;
+    }
+
+    const title = event.title?.toLowerCase() ?? "";
+    const description = event.description?.toLowerCase() ?? "";
+    const organization = event.organization?.toLowerCase() ?? "";
+
+    return (
+      title.includes(normalizedSearchTerm) ||
+      description.includes(normalizedSearchTerm) ||
+      organization.includes(normalizedSearchTerm)
+    );
+  });
+}
+
 // takes a date object and returns a formatted date string
 export function getFormattedDateString(date: Date): string {
   return date.toLocaleDateString("en-US", {


### PR DESCRIPTION
## Developer: Rucha Damle

Closes #212 

### Pull Request Summary

Adds filter functionality to the calendar Filter button. The filter modal lets users filter events by organization and by event location type.

### Modifications

`src/components/calendarFilterModal.tsx`
  - Created a shared filter modal component
  - Added organization and location filter controls
  - Styled modal and filter buttons to match the site
  - Made filter selections apply only after clicking `Apply`

`src/pages/calendar.tsx`
  - Wired the Filter toolbar button to open the filter modal
  - Added filter state for organizations, Virtual, and In Person events
  - Applied selected filters to calendar events and the event list

`src/pages/publicCalendar.tsx`
  - Added the same filtering behavior to the public calendar

`src/utils/events.tsx`
  - Added shared `filterEvents` helper so both calendar pages use the same filtering logic

### Testing Considerations

- Checked that the Filter button opens the modal on the calendar and public calendar
- All filters can be selected/unselected
- Verified that closing modal without clicking "Apply Changes" discards filter changes

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
https://github.com/user-attachments/assets/3e9c9955-f2bf-459a-b0f3-6ee060a172e7

